### PR TITLE
ユーザーIDの設定内容をstring型の設定に統一、user_idのバリデーションをFirebaseのUID似合わせて28文字と英数字の正…

### DIFF
--- a/src/middlewares/imageValidation.ts
+++ b/src/middlewares/imageValidation.ts
@@ -11,7 +11,9 @@ export const imageValidationRules = [
 
     body('user_id')
         .notEmpty().withMessage('ユーザーIDは必須です')
-        .isString().withMessage('ユーザーIDは文字列で指定してください'),
+        .isString().withMessage('ユーザーIDは文字列で指定してください')
+        .isLength({ min: 28, max: 28 }).withMessage('ユーザーIDは28文字である必要があります')
+        .matches(/^[a-zA-Z0-9]+$/).withMessage('ユーザーIDは英数字のみが許可されています'),
 
     body('menu_type')
         .notEmpty().withMessage('メニュータイプは必須です')

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -144,7 +144,7 @@ export class ImageService {
                 storeImageToppingOptions.push({
                     id: Number(image.id),
                     store_id: Number(image.store_id),
-                    user_id: Number(image.user_id),
+                    user_id: image.user_id,
                     menu_type: image.menu_type,
                     menu_name: image.menu_name,
                     image_url: image.image_url,

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -16,7 +16,7 @@ export interface StoreImageUploadData {
 export interface StoreImageDownloadData {
     id: number | string;
     store_id: number | string;
-    user_id: number | string;
+    user_id: string;
     menu_type: number | string;
     menu_name: string;
     image_url: string;


### PR DESCRIPTION
タイトルの通りです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for the user ID field during image uploads to ensure it is exactly 28 alphanumeric characters.
- **Refactor**
  - Updated internal handling of user IDs to consistently use string types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->