### PR TITLE
画像情報取得処理（店舗ID＋画像ID条件１件取得）を追加

### DIFF
--- a/src/controllers/imageController.ts
+++ b/src/controllers/imageController.ts
@@ -89,27 +89,47 @@ export class ImageController {
     }
 
     async getImageByImageId(req: Request, res: Response): Promise<void> {
-        // パラメータから店舗IDと画像IDを取得
-        const storeId = req.params.storeId
-        const imageId = req.params.imageId
+        // バリデーションエラーの確認
+        const errors = validationResult(req)
 
-        // パラメータ検証
-        if (!storeId || !imageId) {
+        // バリデーションエラーがある場合はエラーレスポンスを返す
+        if (!errors.isEmpty) {
             res.status(400).json({
                 status: 'error',
-                message: 'パラメータ不正（店舗ID、画像ID）'
+                message: 'バリデーションエラー',
+                errors: errors.array()
             })
             return
         }
 
-        // サービスクラスから画像IDを条件に画像情報・画像トッピング情報を取得する。
-        const result = await this.imageService.getImageByImageId(storeId, imageId)
+        // パラメータから店舗IDと画像IDを取得
+        const storeId = req.params.storeId
+        const imageId = req.params.imageId
 
-        // 正常終了でリターン
-        res.status(200).json({
-            status: 'success',
-            message: '画像情報を正常取得しました',
-            data: result
-        })
+        try {
+            // サービスクラスから画像IDを条件に画像情報・画像トッピング情報を取得する。
+            const result = await this.imageService.getImageByImageId(storeId, imageId)
+            // 正常終了でリターン
+            res.status(200).json({
+                status: 'success',
+                message: '画像情報を正常取得しました',
+                data: result
+            })
+        } catch (error) {
+            // エラーログ出力
+            console.error(`画像情報取得エラー (storeId: ${storeId}, imageId: ${imageId}):`, error)
+            // サービスからスローされたエラーメッセージに基づいてステータスコードを決定
+            if (error instanceof Error && error.message === '指定された画像情報が存在しません') {
+                res.status(404).json({
+                    status: 'error',
+                    message: error.message
+                })
+            } else {
+                res.status(500).json({
+                    status: 'error',
+                    message: error instanceof Error ? error.message : '画像情報の取得中に予期せぬエラーが発生しました'
+                })
+            }
+        }
     }
 }

--- a/src/controllers/imageController.ts
+++ b/src/controllers/imageController.ts
@@ -87,4 +87,29 @@ export class ImageController {
             })
         }
     }
+
+    async getImageByImageId(req: Request, res: Response): Promise<void> {
+        // パラメータから店舗IDと画像IDを取得
+        const storeId = req.params.storeId
+        const imageId = req.params.imageId
+
+        // パラメータ検証
+        if (!storeId || !imageId) {
+            res.status(400).json({
+                status: 'error',
+                message: 'パラメータ不正（店舗ID、画像ID）'
+            })
+            return
+        }
+
+        // サービスクラスから画像IDを条件に画像情報・画像トッピング情報を取得する。
+        const result = await this.imageService.getImageByImageId(storeId, imageId)
+
+        // 正常終了でリターン
+        res.status(200).json({
+            status: 'success',
+            message: '画像情報を正常取得しました',
+            data: result
+        })
+    }
 }

--- a/src/controllers/storeController.ts
+++ b/src/controllers/storeController.ts
@@ -114,7 +114,6 @@ export class StoreController {
             res.status(500).json({
                 status: 'error',
                 message: error instanceof Error ? error.message : '店舗情報の取得中に予期せぬエラーが発生しました'
-
             })
         }
     }

--- a/src/middlewares/imageValidation.ts
+++ b/src/middlewares/imageValidation.ts
@@ -1,10 +1,10 @@
-import { body } from "express-validator"
+import { body, param } from "express-validator"
 
 /**
  * 画像アップロードのバリデーションルール
  * リクエストの内容を検証し、適切なエラーメッセージを設定
  */
-export const imageValidationRules = [
+export const imageUploadValidationRules = [
     body('store_id')
         .notEmpty().withMessage('店舗IDは必須です')
         .isInt().withMessage('店舗IDは整数で指定してください'),
@@ -46,4 +46,17 @@ export const imageValidationRules = [
         .if(body('topping_selections').exists())
         .notEmpty().withMessage('コールオプションIDは必須です')
         .isInt().withMessage('コールオプションIDは整数で指定してください')
+]
+
+/**
+ * 画像アップロードのバリデーションルール
+ * リクエストの内容を検証し、適切なエラーメッセージを設定
+ */
+export const imageGetValidationRules = [
+    param('storeId')
+        .notEmpty().withMessage('店舗IDは必須です')
+        .isInt().withMessage('店舗IDは整数で指定してください'),
+    param('imageId')
+        .notEmpty().withMessage('画像IDは必須です')
+        .isInt().withMessage('画像IDは整数で指定してください')
 ]

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express"
 import { storeValidationRules } from "../middlewares/validation"
 import { StoreController } from "../controllers/storeController"
 import { ToppingController } from "../controllers/toppingController"
-import { imageValidationRules } from "../middlewares/imageValidation"
+import { imageGetValidationRules, imageUploadValidationRules } from "../middlewares/imageValidation"
 import { ImageController } from "../controllers/imageController"
 import { UserController } from "../controllers/userController"
 import { authenticateUser } from "../middlewares/authMiddleware"
@@ -130,7 +130,7 @@ router.get('/stores/:id/toppingcalls', (req: Request, res: Response) => {
  * @param {File} req.file - アップロードする画像ファイル
  * @returns {object} アップロード結果とステータス情報
  */
-router.post('/stores/:id/images', imageValidationRules, (req: Request, res: Response) => {
+router.post('/stores/:id/images', imageUploadValidationRules, (req: Request, res: Response) => {
     imageController.uploadStoreImage(req, res)
 })
 
@@ -140,10 +140,17 @@ router.post('/stores/:id/images', imageValidationRules, (req: Request, res: Resp
  * @param {string} req.params.id - 対象店舗ID
  * @returns {Array<object>} 画像情報の配列とステータス情報
  */
-router.get(`/stores/:id/images`, (req: Request, res: Response) => {
+router.get(`/stores/:id/images`, imageGetValidationRules, (req: Request, res: Response) => {
     imageController.getStoreImages(req, res)
 })
 
+/**
+ * 画像情報取得エンドポイント（店舗ID＋画像ID指定）
+ * 指定された店舗IDと画像IDに一致する画像情報を1件取得する
+ * @param {string} req.params.storeId - 対象店舗ID
+ * @param {string} req.params.imageId - 対象画像ID
+ * @returns {object} 画像情報とステータス情報（成功時）、またはエラー情報（失敗時）
+ */
 router.get(`/stores/:storeId/images/:imageId`, (req: Request, res: Response) => {
     imageController.getImageByImageId(req, res)
 })

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -135,13 +135,17 @@ router.post('/stores/:id/images', imageValidationRules, (req: Request, res: Resp
 })
 
 /**
- * 店舗画像取得エンドポイント
+ * 店舗画像一覧取得エンドポイント
  * 指定された店舗の全ての画像を取得する
  * @param {string} req.params.id - 対象店舗ID
  * @returns {Array<object>} 画像情報の配列とステータス情報
  */
 router.get(`/stores/:id/images`, (req: Request, res: Response) => {
     imageController.getStoreImages(req, res)
+})
+
+router.get(`/stores/:storeId/images/:imageId`, (req: Request, res: Response) => {
+    imageController.getImageByImageId(req, res)
 })
 
 /**

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -1,5 +1,5 @@
 import prisma from "../prismaClient";
-import { StoreImageDownloadData, StoreImageUploadData } from "../types/image";
+import { StoreImageDownloadData, StoreImageEditData, StoreImageUploadData } from "../types/image";
 import { v4 as uuidv4 } from 'uuid'
 import { bucket } from "../config/firebase";
 
@@ -160,6 +160,64 @@ export class ImageService {
             throw error instanceof Error
                 ? error
                 : new Error('店舗の画像情報取得に失敗しました')
+        }
+    }
+
+    async getImageByImageId(storeId: string | number, imageId: string | number): Promise<StoreImageEditData> {
+        try {
+            // パラメータをBigIntに変換
+            const storeBigInt = BigInt(storeId)
+            const imageBigInt = BigInt(imageId)
+
+            // 画像情報を取得
+            const image = await prisma.image.findFirst({
+                where: {
+                    id: imageBigInt,
+                    store_id: storeBigInt
+                },
+                include: {
+                    image_topping_calls: {
+                        include: {
+                            store_topping_call: {
+                                include: {
+                                    topping: true,
+                                    call_option: true
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+
+            // console.log(JSON.stringify(image, null, 2))
+
+            if (!image) {
+                throw new Error('指定された画像情報が存在しません')
+            }
+
+            // トッピング選択情報を整形
+            const toppingSelections = image.image_topping_calls.map(call => ({
+                topping_id: String(call.topping_id),
+                call_option_id: String(call.store_topping_call.call_option_id),
+                store_topping_call_id: String(call.store_topping_call_id)
+            }))
+            // StoreImageEditData型で返却
+            const editData: StoreImageEditData = {
+                id: String(image.id),
+                store_id: String(image.store_id),
+                user_id: image.user_id,
+                menu_type: image.menu_type,
+                menu_name: image.menu_name,
+                image_url: image.image_url,
+                topping_selections: toppingSelections
+            }
+            // console.log(JSON.stringify(editData, null, 2))
+            return editData
+        } catch (error) {
+            console.error('画像情報取得エラー:', error)
+            throw error instanceof Error
+                ? error
+                : new Error('画像情報の取得に失敗しました')
         }
     }
 

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -27,3 +27,18 @@ export interface StoreImageDownloadData {
         call_option_name: string;
     }[];
 }
+
+// 店舗別画像更新画面用のインターフェース
+export interface StoreImageEditData {
+    id: number | string;
+    store_id: number | string;
+    user_id: string;
+    menu_type: number | string;
+    menu_name: string;
+    image_url: string;
+    topping_selections: {
+        topping_id: number | string;
+        call_option_id: number | string;
+        store_topping_call_id: number | string;
+    }[];
+}


### PR DESCRIPTION
画像情報取得（店舗ID＋画像IDを条件で1件取得）処理を追加。
それに合わせてフロント側に返却するデータ型も追加。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 店舗ごとの特定画像を取得する新しいAPIエンドポイントを追加しました（/stores/:storeId/images/:imageId）。
  - 画像編集画面向けのデータ構造が新たに追加され、画像と関連トッピング情報をまとめて取得できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->