### PR TITLE
ルーティングファイルの分割

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,12 +1,12 @@
 import 'reflect-metadata'
 import 'express-async-errors'
 import express from 'express'
-import middlewares from './middlewares/middlewares'
+import cors from 'cors'
 import router from './routes/routes'
 import config from './config/config'
 import { setupBigIntSerialization } from './utils/bigintExtension'
 import './config/firebase'
-import { errorMiddleware } from './middlewares/errorMiddleware'
+import { AppError, errorMiddleware } from './middlewares/errorMiddleware'
 
 /**
  * BigInt型のJSONシリアライズをサポートするための拡張を設定
@@ -20,15 +20,15 @@ setupBigIntSerialization()
  */
 const app = express()
 
-// リクエストサイズの制限を設定
+/**
+ * アプリケーション全体で使用するミドルウェアを定義
+ * @property {Function} express.json() - JSONリクエストボディをパースするミドルウェア
+ * @property {Function} cors() - CORSを有効にし、異なるオリジンからのリクエストを許可するミドルウェア
+ */
+app.use(cors())
 app.use(express.json({ limit: '10mb' }))
 app.use(express.urlencoded({ extended: true, limit: '10mb' }))
 
-/**
- * ミドルウェアの適用
- * リクエスト処理のためのミドルウェア関数を登録
- */
-app.use(...middlewares)
 
 /**
  * ルーターの適用
@@ -36,6 +36,10 @@ app.use(...middlewares)
  */
 app.use(router)
 
+// 404エラーハンドリング
+app.use((req, res, next) => {
+  next(new AppError("Not Found", 404))
+})
 
 /**
  * エラーハンドリングミドルウェアの適用

--- a/src/routes/image.routes.ts
+++ b/src/routes/image.routes.ts
@@ -1,0 +1,53 @@
+import { Router } from "express"
+import { container } from "tsyringe"
+import { ImageController } from "../controllers/imageController"
+import { imageGetValidationRules, imageUpdateValidationRules, imageUploadValidationRules } from "../middlewares/imageValidation"
+import { authenticateUser } from "../middlewares/authMiddleware"
+
+const imageRouter = Router({ mergeParams: true })
+const imageController = container.resolve(ImageController)
+
+/**
+ * 店舗画像アップロードエンドポイント
+ * 指定された店舗の画像をアップロードする
+ * @param {string} req.params.id - 対象店舗ID
+ * @param {File} req.file - アップロードする画像ファイル
+ * @returns {object} アップロード結果とステータス情報
+ */
+imageRouter.post('/stores/:id/images', imageUploadValidationRules, imageController.uploadStoreImage.bind(imageController))
+
+/**
+ * 店舗画像一覧取得エンドポイント
+ * 指定された店舗の全ての画像を取得する
+ * @param {string} req.params.id - 対象店舗ID
+ * @returns {Array<object>} 画像情報の配列とステータス情報
+ */
+imageRouter.get(`/stores/:id/images`, imageGetValidationRules, imageController.getStoreImages.bind(imageController))
+
+/**
+ * 画像情報取得エンドポイント（店舗ID＋画像ID指定）
+ * 指定された店舗IDと画像IDに一致する画像情報を1件取得する
+ * @param {string} req.params.storeId - 対象店舗ID
+ * @param {string} req.params.imageId - 対象画像ID
+ * @returns {object} 画像情報とステータス情報（成功時）、またはエラー情報（失敗時）
+ */
+imageRouter.get(`/stores/:storeId/images/:imageId`, imageGetValidationRules, imageController.getImageByImageId.bind(imageController))
+
+/**
+ * 画像情報更新エンドポイント（店舗ID＋画像ID指定）
+ * @param {string} req.params.storeId - 対象店舗ID
+ * @param {string} req.params.imageId - 対象画像ID
+ * @param {object} req.body - 更新する画像データ
+ * @returns {object} 更新結果とステータス情報
+ */
+imageRouter.put(`/stores/:storeId/images/:imageId`, imageUpdateValidationRules, imageController.updateStoreImage.bind(imageController))
+
+/**
+ * 店舗画像削除エンドポイント（店舗ID＋画像ID指定）
+ * @param {string} req.params.storeId - 対象店舗ID
+ * @param {string} req.params.imageId - 対象画像ID
+ * @returns {object} 削除結果とステータス情報
+ */
+imageRouter.delete(`/stores/:storeId/images/:imageId`, authenticateUser, imageGetValidationRules, imageController.deleteStoreImage.bind(imageController))
+
+export { imageRouter }

--- a/src/routes/image.routes.ts
+++ b/src/routes/image.routes.ts
@@ -14,7 +14,7 @@ const imageController = container.resolve(ImageController)
  * @param {File} req.file - アップロードする画像ファイル
  * @returns {object} アップロード結果とステータス情報
  */
-imageRouter.post('/stores/:id/images', imageUploadValidationRules, imageController.uploadStoreImage.bind(imageController))
+imageRouter.post('/images', imageUploadValidationRules, imageController.uploadStoreImage.bind(imageController))
 
 /**
  * 店舗画像一覧取得エンドポイント
@@ -22,7 +22,7 @@ imageRouter.post('/stores/:id/images', imageUploadValidationRules, imageControll
  * @param {string} req.params.id - 対象店舗ID
  * @returns {Array<object>} 画像情報の配列とステータス情報
  */
-imageRouter.get(`/stores/:id/images`, imageGetValidationRules, imageController.getStoreImages.bind(imageController))
+imageRouter.get(`/images`, imageGetValidationRules, imageController.getStoreImages.bind(imageController))
 
 /**
  * 画像情報取得エンドポイント（店舗ID＋画像ID指定）
@@ -31,7 +31,7 @@ imageRouter.get(`/stores/:id/images`, imageGetValidationRules, imageController.g
  * @param {string} req.params.imageId - 対象画像ID
  * @returns {object} 画像情報とステータス情報（成功時）、またはエラー情報（失敗時）
  */
-imageRouter.get(`/stores/:storeId/images/:imageId`, imageGetValidationRules, imageController.getImageByImageId.bind(imageController))
+imageRouter.get(`/images/:imageId`, imageGetValidationRules, imageController.getImageByImageId.bind(imageController))
 
 /**
  * 画像情報更新エンドポイント（店舗ID＋画像ID指定）
@@ -40,7 +40,7 @@ imageRouter.get(`/stores/:storeId/images/:imageId`, imageGetValidationRules, ima
  * @param {object} req.body - 更新する画像データ
  * @returns {object} 更新結果とステータス情報
  */
-imageRouter.put(`/stores/:storeId/images/:imageId`, imageUpdateValidationRules, imageController.updateStoreImage.bind(imageController))
+imageRouter.put(`/images/:imageId`, imageUpdateValidationRules, imageController.updateStoreImage.bind(imageController))
 
 /**
  * 店舗画像削除エンドポイント（店舗ID＋画像ID指定）
@@ -48,6 +48,6 @@ imageRouter.put(`/stores/:storeId/images/:imageId`, imageUpdateValidationRules, 
  * @param {string} req.params.imageId - 対象画像ID
  * @returns {object} 削除結果とステータス情報
  */
-imageRouter.delete(`/stores/:storeId/images/:imageId`, authenticateUser, imageGetValidationRules, imageController.deleteStoreImage.bind(imageController))
+imageRouter.delete(`/images/:imageId`, authenticateUser, imageGetValidationRules, imageController.deleteStoreImage.bind(imageController))
 
 export { imageRouter }

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,23 +1,14 @@
 import { Router } from "express"
-import { storeValidationRules } from "../middlewares/validation"
-import { StoreController } from "../controllers/storeController"
-import { ToppingController } from "../controllers/toppingController"
-import { imageGetValidationRules, imageUpdateValidationRules, imageUploadValidationRules } from "../middlewares/imageValidation"
-import { ImageController } from "../controllers/imageController"
-import { UserController } from "../controllers/userController"
-import { authenticateUser } from "../middlewares/authMiddleware"
-import { userValidationRules } from "../middlewares/userValidation"
-import { container } from "tsyringe"
+import { mapRouter, storeRouter } from "./store.routes";
+import { imageRouter } from "./image.routes";
+import { callOptionRouter, toppingRouter } from "./topping.routes";
+import { userRouter } from "./user.routes";
 
 /**
  * Express Routerのインスタンスを作成
  * アプリケーションのルーティングを管理する
  */
 const router = Router();
-const storeController = container.resolve(StoreController)
-const toppingController = container.resolve(ToppingController)
-const imageController = container.resolve(ImageController)
-const userController = container.resolve(UserController)
 
 /**
  * ルートエンドポイント
@@ -36,140 +27,12 @@ router.get('/health', (req, res) => {
     res.send("API is working fine")
 })
 
-/**
- * 店舗情報テーブル追加エンドポイント
- * 指定されたデータをデータベースに保存する
- * リクエストボディからデータを取得する。
- * @param {object} req.body - 保存するテキスト値
- * @returns {object} 作成結果とステータス情報
- */
-router.post('/stores', storeValidationRules, storeController.createStore.bind(storeController))
-
-/**
- * 店舗情報取得エンドポイント
- * 指定されたIDの店舗情報を取得する
- * @param {string} req.params.id - 取得対象の店舗ID
- * @returns {object} 店舗情報とステータス情報
- */
-router.get('/stores/:id', storeController.getStoreById.bind(storeController))
-
-/**
- * 全店舗情報取得エンドポイント
- * データベースに登録されている全ての店舗情報を取得する
- * @returns {Array<object>} 店舗情報の配列とステータス情報
- */
-router.get('/stores', storeController.getStoresAll.bind(storeController))
-
-/**
- * 店舗情報更新エンドポイント
- * 指定されたIDの店舗情報を更新する
- * @param {string} req.params.id - 更新対象の店舗ID
- * @param {object} req.body - 更新するデータ
- * @returns {object} 更新結果とステータス情報
- */
-router.put('/stores/:id', storeValidationRules, storeController.updateStore.bind(storeController))
-
-/**
- * 店舗営業状態変更エンドポイント
- * 指定された店舗の営業状態を「閉店」に変更する
- * @param {string} req.params.id - 対象店舗ID
- * @returns {object} 変更結果とステータス情報
- */
-router.patch('/stores/:id/close', storeController.storeClose.bind(storeController))
-
-/**
- * マップ情報取得エンドポイント
- * 全ての店舗の位置情報を取得する
- * @returns {Array<object>} 位置情報を含む店舗データの配列とステータス情報
- */
-router.get('/maps', storeController.getMapAll.bind(storeController))
-
-/**
- * トッピング情報取得エンドポイント
- * 全てのトッピング情報を取得する
- * @returns {Array<object>} トッピング情報の配列とステータス情報
- */
-router.get('/toppings', toppingController.getToppingAll.bind(toppingController))
-
-/**
- * コールオプション取得エンドポイント
- * 全てのコールオプション情報を取得する
- * @returns {Array<object>} コールオプション情報の配列とステータス情報
- */
-router.get('/calloptions', toppingController.getCallOptionAll.bind(toppingController))
-
-/**
- * 店舗別トッピングコール情報取得エンドポイント
- * 指定された店舗のトッピングコール情報を取得する
- * @param {string} req.params.id - 対象店舗ID
- * @returns {Array<object>} トッピングコール情報の配列とステータス情報
- */
-router.get('/stores/:id/toppingcalls', storeController.getStoreToppingCalls.bind(storeController))
-
-/**
- * 店舗画像アップロードエンドポイント
- * 指定された店舗の画像をアップロードする
- * @param {string} req.params.id - 対象店舗ID
- * @param {File} req.file - アップロードする画像ファイル
- * @returns {object} アップロード結果とステータス情報
- */
-router.post('/stores/:id/images', imageUploadValidationRules, imageController.uploadStoreImage.bind(imageController))
-
-/**
- * 店舗画像一覧取得エンドポイント
- * 指定された店舗の全ての画像を取得する
- * @param {string} req.params.id - 対象店舗ID
- * @returns {Array<object>} 画像情報の配列とステータス情報
- */
-router.get(`/stores/:id/images`, imageGetValidationRules, imageController.getStoreImages.bind(imageController))
-
-/**
- * 画像情報取得エンドポイント（店舗ID＋画像ID指定）
- * 指定された店舗IDと画像IDに一致する画像情報を1件取得する
- * @param {string} req.params.storeId - 対象店舗ID
- * @param {string} req.params.imageId - 対象画像ID
- * @returns {object} 画像情報とステータス情報（成功時）、またはエラー情報（失敗時）
- */
-router.get(`/stores/:storeId/images/:imageId`, imageGetValidationRules, imageController.getImageByImageId.bind(imageController))
-
-/**
- * 画像情報更新エンドポイント（店舗ID＋画像ID指定）
- * @param {string} req.params.storeId - 対象店舗ID
- * @param {string} req.params.imageId - 対象画像ID
- * @param {object} req.body - 更新する画像データ
- * @returns {object} 更新結果とステータス情報
- */
-router.put(`/stores/:storeId/images/:imageId`, imageUpdateValidationRules, imageController.updateStoreImage.bind(imageController))
-
-/**
- * 店舗画像削除エンドポイント（店舗ID＋画像ID指定）
- * @param {string} req.params.storeId - 対象店舗ID
- * @param {string} req.params.imageId - 対象画像ID
- * @returns {object} 削除結果とステータス情報
- */
-router.delete(`/stores/:storeId/images/:imageId`, authenticateUser, imageGetValidationRules, imageController.deleteStoreImage.bind(imageController))
-
-/**
- * フォーマット済みトッピングコールオプション取得エンドポイント
- * フロントエンド表示用にフォーマットされたトッピングとコールオプションの関連情報を取得する
- * @returns {object} フォーマット済みのトッピングとコールオプションデータとステータス情報
- */
-router.get(`/toppings/calloptions`, toppingController.getFormattedToppingCollOption.bind(toppingController))
-
-/**
- * ユーザー作成エンドポイント
- * 新しいユーザーを作成する
- * @param {object} req.body - ユーザー情報
- * @returns {object} 作成されたユーザー情報とステータス情報
- */
-router.post(`/users`, authenticateUser, userValidationRules, userController.createUser.bind(userController))
-
-/**
- * ユーザー情報取得エンドポイント
- * 指定されたUIDのユーザー情報を取得する
- * @param {string} req.params.uid - 取得対象のユーザーUID
- * @returns {object} ユーザー情報とステータス情報
- */
-router.get('/users/:uid', authenticateUser, userController.getUserByUid.bind(userController))
+// 分割したルーターをマウント
+router.use("/stores", storeRouter)
+router.use("/stores/:storeId/images", imageRouter)
+router.use("/maps", mapRouter)
+router.use("/toppings", toppingRouter)
+router.use("/calloptions", callOptionRouter)
+router.use("/users", userRouter)
 
 export default router

--- a/src/routes/store.routes.ts
+++ b/src/routes/store.routes.ts
@@ -1,0 +1,67 @@
+import { Router } from "express";
+import { container } from "tsyringe";
+import { StoreController } from "../controllers/storeController";
+import { storeValidationRules } from "../middlewares/validation";
+
+const storeRouter = Router()
+const storeController = container.resolve(StoreController)
+
+
+/**
+ * 店舗情報テーブル追加エンドポイント
+ * 指定されたデータをデータベースに保存する
+ * リクエストボディからデータを取得する。
+ * @param {object} req.body - 保存するテキスト値
+ * @returns {object} 作成結果とステータス情報
+ */
+storeRouter.post('/stores', storeValidationRules, storeController.createStore.bind(storeController))
+
+/**
+ * 店舗情報取得エンドポイント
+ * 指定されたIDの店舗情報を取得する
+ * @param {string} req.params.id - 取得対象の店舗ID
+ * @returns {object} 店舗情報とステータス情報
+ */
+storeRouter.get('/stores/:id', storeController.getStoreById.bind(storeController))
+
+/**
+ * 全店舗情報取得エンドポイント
+ * データベースに登録されている全ての店舗情報を取得する
+ * @returns {Array<object>} 店舗情報の配列とステータス情報
+ */
+storeRouter.get('/stores', storeController.getStoresAll.bind(storeController))
+
+/**
+ * 店舗情報更新エンドポイント
+ * 指定されたIDの店舗情報を更新する
+ * @param {string} req.params.id - 更新対象の店舗ID
+ * @param {object} req.body - 更新するデータ
+ * @returns {object} 更新結果とステータス情報
+ */
+storeRouter.put('/stores/:id', storeValidationRules, storeController.updateStore.bind(storeController))
+
+/**
+ * 店舗営業状態変更エンドポイント
+ * 指定された店舗の営業状態を「閉店」に変更する
+ * @param {string} req.params.id - 対象店舗ID
+ * @returns {object} 変更結果とステータス情報
+ */
+storeRouter.patch('/stores/:id/close', storeController.storeClose.bind(storeController))
+
+/**
+ * マップ情報取得エンドポイント
+ * 全ての店舗の位置情報を取得する
+ * @returns {Array<object>} 位置情報を含む店舗データの配列とステータス情報
+ */
+const mapRouter = Router()
+mapRouter.get('/maps', storeController.getMapAll.bind(storeController))
+
+/**
+ * 店舗別トッピングコール情報取得エンドポイント
+ * 指定された店舗のトッピングコール情報を取得する
+ * @param {string} req.params.id - 対象店舗ID
+ * @returns {Array<object>} トッピングコール情報の配列とステータス情報
+ */
+storeRouter.get('/stores/:id/toppingcalls', storeController.getStoreToppingCalls.bind(storeController))
+
+export { storeRouter, mapRouter }

--- a/src/routes/store.routes.ts
+++ b/src/routes/store.routes.ts
@@ -14,7 +14,7 @@ const storeController = container.resolve(StoreController)
  * @param {object} req.body - 保存するテキスト値
  * @returns {object} 作成結果とステータス情報
  */
-storeRouter.post('/stores', storeValidationRules, storeController.createStore.bind(storeController))
+storeRouter.post('/', storeValidationRules, storeController.createStore.bind(storeController))
 
 /**
  * 店舗情報取得エンドポイント
@@ -22,14 +22,14 @@ storeRouter.post('/stores', storeValidationRules, storeController.createStore.bi
  * @param {string} req.params.id - 取得対象の店舗ID
  * @returns {object} 店舗情報とステータス情報
  */
-storeRouter.get('/stores/:id', storeController.getStoreById.bind(storeController))
+storeRouter.get('/:id', storeController.getStoreById.bind(storeController))
 
 /**
  * 全店舗情報取得エンドポイント
  * データベースに登録されている全ての店舗情報を取得する
  * @returns {Array<object>} 店舗情報の配列とステータス情報
  */
-storeRouter.get('/stores', storeController.getStoresAll.bind(storeController))
+storeRouter.get('/', storeController.getStoresAll.bind(storeController))
 
 /**
  * 店舗情報更新エンドポイント
@@ -38,7 +38,7 @@ storeRouter.get('/stores', storeController.getStoresAll.bind(storeController))
  * @param {object} req.body - 更新するデータ
  * @returns {object} 更新結果とステータス情報
  */
-storeRouter.put('/stores/:id', storeValidationRules, storeController.updateStore.bind(storeController))
+storeRouter.put('/:id', storeValidationRules, storeController.updateStore.bind(storeController))
 
 /**
  * 店舗営業状態変更エンドポイント
@@ -46,7 +46,7 @@ storeRouter.put('/stores/:id', storeValidationRules, storeController.updateStore
  * @param {string} req.params.id - 対象店舗ID
  * @returns {object} 変更結果とステータス情報
  */
-storeRouter.patch('/stores/:id/close', storeController.storeClose.bind(storeController))
+storeRouter.patch('/:id/close', storeController.storeClose.bind(storeController))
 
 /**
  * マップ情報取得エンドポイント
@@ -54,7 +54,7 @@ storeRouter.patch('/stores/:id/close', storeController.storeClose.bind(storeCont
  * @returns {Array<object>} 位置情報を含む店舗データの配列とステータス情報
  */
 const mapRouter = Router()
-mapRouter.get('/maps', storeController.getMapAll.bind(storeController))
+mapRouter.get('/', storeController.getMapAll.bind(storeController))
 
 /**
  * 店舗別トッピングコール情報取得エンドポイント
@@ -62,6 +62,6 @@ mapRouter.get('/maps', storeController.getMapAll.bind(storeController))
  * @param {string} req.params.id - 対象店舗ID
  * @returns {Array<object>} トッピングコール情報の配列とステータス情報
  */
-storeRouter.get('/stores/:id/toppingcalls', storeController.getStoreToppingCalls.bind(storeController))
+storeRouter.get('/:id/toppingcalls', storeController.getStoreToppingCalls.bind(storeController))
 
 export { storeRouter, mapRouter }

--- a/src/routes/topping.routes.ts
+++ b/src/routes/topping.routes.ts
@@ -1,0 +1,30 @@
+import { Router } from "express"
+import { container } from "tsyringe"
+import { ToppingController } from "../controllers/toppingController"
+
+const toppingRouter = Router()
+const toppingController = container.resolve(ToppingController)
+
+/**
+ * トッピング情報取得エンドポイント
+ * 全てのトッピング情報を取得する
+ * @returns {Array<object>} トッピング情報の配列とステータス情報
+ */
+toppingRouter.get('/toppings', toppingController.getToppingAll.bind(toppingController))
+
+/**
+ * コールオプション取得エンドポイント
+ * 全てのコールオプション情報を取得する
+ * @returns {Array<object>} コールオプション情報の配列とステータス情報
+ */
+const callOptionRouter = Router()
+callOptionRouter.get('/calloptions', toppingController.getCallOptionAll.bind(toppingController))
+
+/**
+ * フォーマット済みトッピングコールオプション取得エンドポイント
+ * フロントエンド表示用にフォーマットされたトッピングとコールオプションの関連情報を取得する
+ * @returns {object} フォーマット済みのトッピングとコールオプションデータとステータス情報
+ */
+toppingRouter.get(`/toppings/calloptions`, toppingController.getFormattedToppingCollOption.bind(toppingController))
+
+export { toppingRouter, callOptionRouter }

--- a/src/routes/topping.routes.ts
+++ b/src/routes/topping.routes.ts
@@ -10,7 +10,7 @@ const toppingController = container.resolve(ToppingController)
  * 全てのトッピング情報を取得する
  * @returns {Array<object>} トッピング情報の配列とステータス情報
  */
-toppingRouter.get('/toppings', toppingController.getToppingAll.bind(toppingController))
+toppingRouter.get('/', toppingController.getToppingAll.bind(toppingController))
 
 /**
  * コールオプション取得エンドポイント
@@ -18,13 +18,13 @@ toppingRouter.get('/toppings', toppingController.getToppingAll.bind(toppingContr
  * @returns {Array<object>} コールオプション情報の配列とステータス情報
  */
 const callOptionRouter = Router()
-callOptionRouter.get('/calloptions', toppingController.getCallOptionAll.bind(toppingController))
+callOptionRouter.get('/', toppingController.getCallOptionAll.bind(toppingController))
 
 /**
  * フォーマット済みトッピングコールオプション取得エンドポイント
  * フロントエンド表示用にフォーマットされたトッピングとコールオプションの関連情報を取得する
  * @returns {object} フォーマット済みのトッピングとコールオプションデータとステータス情報
  */
-toppingRouter.get(`/toppings/calloptions`, toppingController.getFormattedToppingCollOption.bind(toppingController))
+toppingRouter.get(`/calloptions`, toppingController.getFormattedToppingCollOption.bind(toppingController))
 
 export { toppingRouter, callOptionRouter }

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -13,7 +13,7 @@ const userController = container.resolve(UserController)
  * @param {object} req.body - ユーザー情報
  * @returns {object} 作成されたユーザー情報とステータス情報
  */
-userRouter.post(`/users`, authenticateUser, userValidationRules, userController.createUser.bind(userController))
+userRouter.post(`/`, authenticateUser, userValidationRules, userController.createUser.bind(userController))
 
 /**
  * ユーザー情報取得エンドポイント
@@ -21,6 +21,6 @@ userRouter.post(`/users`, authenticateUser, userValidationRules, userController.
  * @param {string} req.params.uid - 取得対象のユーザーUID
  * @returns {object} ユーザー情報とステータス情報
  */
-userRouter.get('/users/:uid', authenticateUser, userController.getUserByUid.bind(userController))
+userRouter.get('/:uid', authenticateUser, userController.getUserByUid.bind(userController))
 
 export { userRouter }

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import { UserController } from "../controllers/userController";
+import { container } from "tsyringe";
+import { authenticateUser } from "../middlewares/authMiddleware";
+import { userValidationRules } from "../middlewares/userValidation";
+
+const userRouter = Router()
+const userController = container.resolve(UserController)
+
+/**
+ * ユーザー作成エンドポイント
+ * 新しいユーザーを作成する
+ * @param {object} req.body - ユーザー情報
+ * @returns {object} 作成されたユーザー情報とステータス情報
+ */
+userRouter.post(`/users`, authenticateUser, userValidationRules, userController.createUser.bind(userController))
+
+/**
+ * ユーザー情報取得エンドポイント
+ * 指定されたUIDのユーザー情報を取得する
+ * @param {string} req.params.uid - 取得対象のユーザーUID
+ * @returns {object} ユーザー情報とステータス情報
+ */
+userRouter.get('/users/:uid', authenticateUser, userController.getUserByUid.bind(userController))
+
+export { userRouter }


### PR DESCRIPTION
ルーティングファイルの分割
現在はsrc/routes/routes.tsに全てのルーティングが記述されていますが、今後APIが増えていくと、このファイルは非常に大きくなり、メンテナンス性が低下します。
提案: stores.routes.ts、users.routes.tsのように、関連するエンドポイントごとにファイルを分割します