### PR TITLE
DI不具合修正（PrismaClientという部品が、DIコンテナ（道具箱）に登録される前に、それを使おうとしてしまった）

### DIFF
--- a/src/routes/image.routes.ts
+++ b/src/routes/image.routes.ts
@@ -1,11 +1,10 @@
-import { Router } from "express"
+import { NextFunction, Request, Response, Router } from "express"
 import { container } from "tsyringe"
 import { ImageController } from "../controllers/imageController"
 import { imageGetValidationRules, imageUpdateValidationRules, imageUploadValidationRules } from "../middlewares/imageValidation"
 import { authenticateUser } from "../middlewares/authMiddleware"
 
 const imageRouter = Router({ mergeParams: true })
-const imageController = container.resolve(ImageController)
 
 /**
  * 店舗画像アップロードエンドポイント
@@ -14,16 +13,18 @@ const imageController = container.resolve(ImageController)
  * @param {File} req.file - アップロードする画像ファイル
  * @returns {object} アップロード結果とステータス情報
  */
-imageRouter.post('/', imageUploadValidationRules, imageController.uploadStoreImage.bind(imageController))
-
+imageRouter.post('/', imageUploadValidationRules, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(ImageController).uploadStoreImage(req, res).catch(next)
+)
 /**
  * 店舗画像一覧取得エンドポイント
  * 指定された店舗の全ての画像を取得する
  * @param {string} req.params.storeId - 対象店舗ID
  * @returns {Array<object>} 画像情報の配列とステータス情報
  */
-imageRouter.get(`/`, imageGetValidationRules, imageController.getStoreImages.bind(imageController))
-
+imageRouter.get(`/`, imageGetValidationRules, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(ImageController).getStoreImages(req, res).catch(next)
+)
 /**
  * 画像情報取得エンドポイント（店舗ID＋画像ID指定）
  * 指定された店舗IDと画像IDに一致する画像情報を1件取得する
@@ -31,8 +32,9 @@ imageRouter.get(`/`, imageGetValidationRules, imageController.getStoreImages.bin
  * @param {string} req.params.imageId - 対象画像ID
  * @returns {object} 画像情報とステータス情報（成功時）、またはエラー情報（失敗時）
  */
-imageRouter.get(`/:imageId`, imageGetValidationRules, imageController.getImageByImageId.bind(imageController))
-
+imageRouter.get(`/:imageId`, imageGetValidationRules, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(ImageController).getImageByImageId(req, res).catch(next)
+)
 /**
  * 画像情報更新エンドポイント（店舗ID＋画像ID指定）
  * @param {string} req.params.storeId - 対象店舗ID
@@ -40,14 +42,16 @@ imageRouter.get(`/:imageId`, imageGetValidationRules, imageController.getImageBy
  * @param {object} req.body - 更新する画像データ
  * @returns {object} 更新結果とステータス情報
  */
-imageRouter.put(`/:imageId`, imageUpdateValidationRules, imageController.updateStoreImage.bind(imageController))
-
+imageRouter.put(`/:imageId`, imageUpdateValidationRules, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(ImageController).updateStoreImage(req, res).catch(next)
+)
 /**
  * 店舗画像削除エンドポイント（店舗ID＋画像ID指定）
  * @param {string} req.params.storeId - 対象店舗ID
  * @param {string} req.params.imageId - 対象画像ID
  * @returns {object} 削除結果とステータス情報
  */
-imageRouter.delete(`/:imageId`, authenticateUser, imageGetValidationRules, imageController.deleteStoreImage.bind(imageController))
-
+imageRouter.delete(`/:imageId`, authenticateUser, imageGetValidationRules, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(ImageController).deleteStoreImage(req, res).catch(next)
+)
 export { imageRouter }

--- a/src/routes/store.routes.ts
+++ b/src/routes/store.routes.ts
@@ -1,10 +1,9 @@
-import { Router } from "express";
+import { NextFunction, Request, Response, Router } from "express";
 import { container } from "tsyringe";
 import { StoreController } from "../controllers/storeController";
 import { storeValidationRules } from "../middlewares/validation";
 
 const storeRouter = Router()
-const storeController = container.resolve(StoreController)
 
 
 /**
@@ -14,7 +13,8 @@ const storeController = container.resolve(StoreController)
  * @param {object} req.body - 保存するテキスト値
  * @returns {object} 作成結果とステータス情報
  */
-storeRouter.post('/', storeValidationRules, storeController.createStore.bind(storeController))
+storeRouter.post('/', storeValidationRules, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(StoreController).createStore(req, res).catch(next))
 
 /**
  * 店舗情報取得エンドポイント
@@ -22,14 +22,17 @@ storeRouter.post('/', storeValidationRules, storeController.createStore.bind(sto
  * @param {string} req.params.id - 取得対象の店舗ID
  * @returns {object} 店舗情報とステータス情報
  */
-storeRouter.get('/:id', storeController.getStoreById.bind(storeController))
+storeRouter.get('/:id', (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(StoreController).getStoreById(req, res).catch(next))
 
 /**
  * 全店舗情報取得エンドポイント
  * データベースに登録されている全ての店舗情報を取得する
  * @returns {Array<object>} 店舗情報の配列とステータス情報
  */
-storeRouter.get('/', storeController.getStoresAll.bind(storeController))
+storeRouter.get('/', (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(StoreController).getStoresAll(req, res).catch(next)
+)
 
 /**
  * 店舗情報更新エンドポイント
@@ -38,7 +41,9 @@ storeRouter.get('/', storeController.getStoresAll.bind(storeController))
  * @param {object} req.body - 更新するデータ
  * @returns {object} 更新結果とステータス情報
  */
-storeRouter.put('/:id', storeValidationRules, storeController.updateStore.bind(storeController))
+storeRouter.put('/:id', storeValidationRules, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(StoreController).updateStore(req, res).catch(next)
+);
 
 /**
  * 店舗営業状態変更エンドポイント
@@ -46,7 +51,9 @@ storeRouter.put('/:id', storeValidationRules, storeController.updateStore.bind(s
  * @param {string} req.params.id - 対象店舗ID
  * @returns {object} 変更結果とステータス情報
  */
-storeRouter.patch('/:id/close', storeController.storeClose.bind(storeController))
+storeRouter.patch('/:id/close', (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(StoreController).storeClose(req, res).catch(next)
+);
 
 /**
  * 店舗別トッピングコール情報取得エンドポイント
@@ -54,7 +61,9 @@ storeRouter.patch('/:id/close', storeController.storeClose.bind(storeController)
  * @param {string} req.params.id - 対象店舗ID
  * @returns {Array<object>} トッピングコール情報の配列とステータス情報
  */
-storeRouter.get('/:id/toppingcalls', storeController.getStoreToppingCalls.bind(storeController))
+storeRouter.get('/:id/toppingcalls', (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(StoreController).getStoreToppingCalls(req, res).catch(next)
+)
 
 /**
  * マップ情報取得エンドポイント
@@ -62,6 +71,8 @@ storeRouter.get('/:id/toppingcalls', storeController.getStoreToppingCalls.bind(s
  * @returns {Array<object>} 位置情報を含む店舗データの配列とステータス情報
  */
 const mapRouter = Router()
-mapRouter.get('/', storeController.getMapAll.bind(storeController))
+mapRouter.get('/', (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(StoreController).getMapAll(req, res).catch(next)
+);
 
 export { storeRouter, mapRouter }

--- a/src/routes/topping.routes.ts
+++ b/src/routes/topping.routes.ts
@@ -1,30 +1,33 @@
-import { Router } from "express"
+import { NextFunction, Request, Response, Router } from "express"
 import { container } from "tsyringe"
 import { ToppingController } from "../controllers/toppingController"
 
 const toppingRouter = Router()
-const toppingController = container.resolve(ToppingController)
 
 /**
  * トッピング情報取得エンドポイント
  * 全てのトッピング情報を取得する
  * @returns {Array<object>} トッピング情報の配列とステータス情報
  */
-toppingRouter.get('/', toppingController.getToppingAll.bind(toppingController))
+toppingRouter.get('/', (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(ToppingController).getToppingAll(req, res).catch(next)
+)
 
 /**
  * フォーマット済みトッピングコールオプション取得エンドポイント
  * フロントエンド表示用にフォーマットされたトッピングとコールオプションの関連情報を取得する
  * @returns {object} フォーマット済みのトッピングとコールオプションデータとステータス情報
  */
-toppingRouter.get(`/calloptions/formatted`, toppingController.getFormattedToppingCollOption.bind(toppingController))
-
+toppingRouter.get(`/calloptions/formatted`, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(ToppingController).getFormattedToppingCollOption(req, res).catch(next)
+)
 /**
  * コールオプション取得エンドポイント
  * 全てのコールオプション情報を取得する
  * @returns {Array<object>} コールオプション情報の配列とステータス情報
  */
 const callOptionRouter = Router()
-callOptionRouter.get('/', toppingController.getCallOptionAll.bind(toppingController))
-
+callOptionRouter.get('/', (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(ToppingController).getCallOptionAll(req, res).catch(next)
+)
 export { toppingRouter, callOptionRouter }

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -1,11 +1,10 @@
-import { Router } from "express";
+import { NextFunction, Request, Response, Router } from "express";
 import { UserController } from "../controllers/userController";
 import { container } from "tsyringe";
 import { authenticateUser } from "../middlewares/authMiddleware";
 import { userValidationRules } from "../middlewares/userValidation";
 
 const userRouter = Router()
-const userController = container.resolve(UserController)
 
 /**
  * ユーザー作成エンドポイント
@@ -13,14 +12,16 @@ const userController = container.resolve(UserController)
  * @param {object} req.body - ユーザー情報
  * @returns {object} 作成されたユーザー情報とステータス情報
  */
-userRouter.post(`/`, authenticateUser, userValidationRules, userController.createUser.bind(userController))
-
+userRouter.post(`/`, authenticateUser, userValidationRules, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(UserController).createUser(req, res).catch(next)
+)
 /**
  * ユーザー情報取得エンドポイント
  * 指定されたUIDのユーザー情報を取得する
  * @param {string} req.params.uid - 取得対象のユーザーUID
  * @returns {object} ユーザー情報とステータス情報
  */
-userRouter.get('/:uid', authenticateUser, userController.getUserByUid.bind(userController))
-
+userRouter.get('/:uid', authenticateUser, (req: Request, res: Response, next: NextFunction) =>
+    container.resolve(UserController).getUserByUid(req, res).catch(next)
+)
 export { userRouter }

--- a/src/services/storeServices.ts
+++ b/src/services/storeServices.ts
@@ -14,7 +14,7 @@ export class StoreService {
 
     constructor(
         @inject(PRISMA_CLIENT) private prisma: PrismaClient,
-        private geoCodingService: GeocodingService
+        @inject(GeocodingService) private geoCodingService: GeocodingService
     ) { }
     /**
    * 店舗情報とマップ情報を同時に登録する


### PR DESCRIPTION

原因 | 解決策
-- | --
概要 | 部品がDIコンテナに登録される前に、その部品を使おうとしていた。 | 実際にリクエストが来てから、DIコンテナ経由で部品を使うようにタイミングを遅らせた（遅延解決）。
コード | ルーティングファイルのトップレベルでコントローラーを解決していた。 | 各ルートハンドラーの中でコントローラーを解決するように変更した。
メリット |   | アプリケーションの起動順序に依存しない、より安全で堅牢なコードになった。これはDIを利用する上でのベストプラクティスです。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 画像、店舗、トッピング、ユーザー関連APIのエラーハンドリングが改善され、非同期エラーが適切に処理されるようになりました。

- **リファクタリング**
  - 各APIの内部処理が見直され、リクエストごとにコントローラーが生成されるようになりました。
  - サービスの依存性注入が明示的になり、安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->