### PR TITLE
routeのリファクタリング（ヘルパー関数を作成）

### DIFF
--- a/src/routes/store.routes.ts
+++ b/src/routes/store.routes.ts
@@ -1,7 +1,7 @@
-import { NextFunction, Request, Response, Router } from "express";
-import { container } from "tsyringe";
+import { Router } from "express";
 import { StoreController } from "../controllers/storeController";
 import { storeValidationRules } from "../middlewares/validation";
+import { createHandler } from "../utils/routeHandler";
 
 const storeRouter = Router()
 
@@ -13,8 +13,7 @@ const storeRouter = Router()
  * @param {object} req.body - 保存するテキスト値
  * @returns {object} 作成結果とステータス情報
  */
-storeRouter.post('/', storeValidationRules, (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(StoreController).createStore(req, res).catch(next))
+storeRouter.post('/', storeValidationRules, createHandler(StoreController, "createStore"))
 
 /**
  * 店舗情報取得エンドポイント
@@ -22,17 +21,14 @@ storeRouter.post('/', storeValidationRules, (req: Request, res: Response, next: 
  * @param {string} req.params.id - 取得対象の店舗ID
  * @returns {object} 店舗情報とステータス情報
  */
-storeRouter.get('/:id', (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(StoreController).getStoreById(req, res).catch(next))
+storeRouter.get('/:id', createHandler(StoreController, 'getStoreById'))
 
 /**
  * 全店舗情報取得エンドポイント
  * データベースに登録されている全ての店舗情報を取得する
  * @returns {Array<object>} 店舗情報の配列とステータス情報
  */
-storeRouter.get('/', (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(StoreController).getStoresAll(req, res).catch(next)
-)
+storeRouter.get('/', createHandler(StoreController, 'getStoresAll'))
 
 /**
  * 店舗情報更新エンドポイント
@@ -41,9 +37,7 @@ storeRouter.get('/', (req: Request, res: Response, next: NextFunction) =>
  * @param {object} req.body - 更新するデータ
  * @returns {object} 更新結果とステータス情報
  */
-storeRouter.put('/:id', storeValidationRules, (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(StoreController).updateStore(req, res).catch(next)
-);
+storeRouter.put('/:id', storeValidationRules, createHandler(StoreController, 'updateStore'))
 
 /**
  * 店舗営業状態変更エンドポイント
@@ -51,9 +45,7 @@ storeRouter.put('/:id', storeValidationRules, (req: Request, res: Response, next
  * @param {string} req.params.id - 対象店舗ID
  * @returns {object} 変更結果とステータス情報
  */
-storeRouter.patch('/:id/close', (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(StoreController).storeClose(req, res).catch(next)
-);
+storeRouter.patch('/:id/close', createHandler(StoreController, 'storeClose'))
 
 /**
  * 店舗別トッピングコール情報取得エンドポイント
@@ -61,9 +53,7 @@ storeRouter.patch('/:id/close', (req: Request, res: Response, next: NextFunction
  * @param {string} req.params.id - 対象店舗ID
  * @returns {Array<object>} トッピングコール情報の配列とステータス情報
  */
-storeRouter.get('/:id/toppingcalls', (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(StoreController).getStoreToppingCalls(req, res).catch(next)
-)
+storeRouter.get('/:id/toppingcalls', createHandler(StoreController, 'getStoreToppingCalls'))
 
 /**
  * マップ情報取得エンドポイント
@@ -71,8 +61,6 @@ storeRouter.get('/:id/toppingcalls', (req: Request, res: Response, next: NextFun
  * @returns {Array<object>} 位置情報を含む店舗データの配列とステータス情報
  */
 const mapRouter = Router()
-mapRouter.get('/', (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(StoreController).getMapAll(req, res).catch(next)
-);
+mapRouter.get('/', createHandler(StoreController, 'getMapAll'))
 
 export { storeRouter, mapRouter }

--- a/src/routes/topping.routes.ts
+++ b/src/routes/topping.routes.ts
@@ -1,6 +1,6 @@
-import { NextFunction, Request, Response, Router } from "express"
-import { container } from "tsyringe"
+import { Router } from "express"
 import { ToppingController } from "../controllers/toppingController"
+import { createHandler } from "../utils/routeHandler"
 
 const toppingRouter = Router()
 
@@ -9,25 +9,20 @@ const toppingRouter = Router()
  * 全てのトッピング情報を取得する
  * @returns {Array<object>} トッピング情報の配列とステータス情報
  */
-toppingRouter.get('/', (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(ToppingController).getToppingAll(req, res).catch(next)
-)
+toppingRouter.get('/', createHandler(ToppingController, 'getToppingAll'))
 
 /**
  * フォーマット済みトッピングコールオプション取得エンドポイント
  * フロントエンド表示用にフォーマットされたトッピングとコールオプションの関連情報を取得する
  * @returns {object} フォーマット済みのトッピングとコールオプションデータとステータス情報
  */
-toppingRouter.get(`/calloptions/formatted`, (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(ToppingController).getFormattedToppingCollOption(req, res).catch(next)
-)
+toppingRouter.get(`/calloptions/formatted`, createHandler(ToppingController, 'getFormattedToppingCollOption'))
 /**
  * コールオプション取得エンドポイント
  * 全てのコールオプション情報を取得する
  * @returns {Array<object>} コールオプション情報の配列とステータス情報
  */
 const callOptionRouter = Router()
-callOptionRouter.get('/', (req: Request, res: Response, next: NextFunction) =>
-    container.resolve(ToppingController).getCallOptionAll(req, res).catch(next)
-)
+callOptionRouter.get('/', createHandler(ToppingController, 'getCallOptionAll'))
+
 export { toppingRouter, callOptionRouter }

--- a/src/utils/routeHandler.ts
+++ b/src/utils/routeHandler.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from "express";
+import { container } from "tsyringe";
+import { constructor } from "tsyringe/dist/typings/types";
+
+// コントローラーのメソッドの型を定義
+type ControllerMethod = (req: Request, res: Response) => Promise<void | Response>
+
+export function createHandler<T>(
+    controller: constructor<T>,
+    methodName: keyof T
+) {
+    return (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const controllerInstance = container.resolve<T>(controller)
+            // メソッドを安全にキャスト
+            const method = controllerInstance[methodName] as unknown as ControllerMethod
+            method.call(controllerInstance, req, res).catch(next)
+        } catch (error) {
+            next(error)
+        }
+    }
+}

--- a/src/utils/routeHandler.ts
+++ b/src/utils/routeHandler.ts
@@ -1,20 +1,28 @@
 import { NextFunction, Request, Response } from "express";
 import { container } from "tsyringe";
-import { constructor } from "tsyringe/dist/typings/types";
+import { constructor as tSyringeConstructor } from "tsyringe/dist/typings/types";
+import { AppError } from "../middlewares/errorMiddleware";
 
 // コントローラーのメソッドの型を定義
 type ControllerMethod = (req: Request, res: Response) => Promise<void | Response>
 
 export function createHandler<T>(
-    controller: constructor<T>,
+    controller: tSyringeConstructor<T>,
     methodName: keyof T
 ) {
     return (req: Request, res: Response, next: NextFunction) => {
         try {
             const controllerInstance = container.resolve<T>(controller)
             // メソッドを安全にキャスト
-            const method = controllerInstance[methodName] as unknown as ControllerMethod
-            method.call(controllerInstance, req, res).catch(next)
+            const method = controllerInstance[methodName]
+            if (typeof method === 'function') {
+                const result = (method as ControllerMethod).call(controllerInstance, req, res)
+                if (result && typeof result.catch === 'function') {
+                    result.catch(next)
+                }
+            } else {
+                next(new AppError(`${String(methodName)}はコントローラに存在しません`, 500))
+            }
         } catch (error) {
             next(error)
         }


### PR DESCRIPTION
各ルートハンドラで同じようなコードが繰り返されています。これにより、将来的なメンテナンスが煩雑になる可能性があります。DRY (Don't Repeat Yourself) の原則に従い、このロジックを共通化するヘルパー関数を作成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * ルートハンドラーの実装を統一的なユーティリティ関数で簡素化し、エラーハンドリングを中央集約化しました。  
  * これにより、ストアおよびトッピング関連のエンドポイントの安定性と保守性が向上しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->