### PR TITLE
設定値（APIキーなど）のDI対応（リファクタリング）

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,7 @@ import './config/firebase'
 import { AppError, errorMiddleware } from './middlewares/errorMiddleware'
 import { PrismaClient } from '@prisma/client'
 import { container } from 'tsyringe'
-import { PRISMA_CLIENT } from './di.token'
+import { GOOGLE_MAP_API_KEY, PRISMA_CLIENT } from './di.token'
 
 /**
  * PrismaClientのインスタンスをDIコンテナに登録
@@ -30,6 +30,11 @@ const prisma = new PrismaClient({
   }
 })
 container.registerInstance(PRISMA_CLIENT, prisma)
+
+/**
+ * Google Maps APIキーをDIコンテナに登録
+ */
+container.register(GOOGLE_MAP_API_KEY, { useValue: config.google.mapsApiKey })
 
 /**
  * BigInt型のJSONシリアライズをサポートするための拡張を設定

--- a/src/di.token.ts
+++ b/src/di.token.ts
@@ -1,1 +1,2 @@
 export const PRISMA_CLIENT = Symbol.for('PrismaClient')
+export const GOOGLE_MAP_API_KEY = Symbol.for('GoogleMapsApiKey')

--- a/src/services/geocodingService.ts
+++ b/src/services/geocodingService.ts
@@ -1,7 +1,7 @@
 import NodeGeocoder from 'node-geocoder';
-import { injectable } from 'tsyringe';
+import { inject, injectable } from 'tsyringe';
 import { AppError } from '../middlewares/errorMiddleware';
-import config from '../config/config';
+import { GOOGLE_MAP_API_KEY } from '../di.token';
 
 /**
  * ジオコーディングサービス
@@ -11,11 +11,11 @@ import config from '../config/config';
 export class GeocodingService {
     private geocoder: NodeGeocoder.Geocoder;
     // サービス初期化
-    constructor() {
+    constructor(@inject(GOOGLE_MAP_API_KEY) apiKey: string) {
         // geocoderの設定
         const options: NodeGeocoder.Options = {
             provider: 'google',
-            apiKey: config.google.mapsApiKey,
+            apiKey,
             formatter: null
         }
 


### PR DESCRIPTION
GeocodingServiceのように、もしAPIキーが必要になった場合、
サービスクラスの内部で直接process.env.API_KEYのように環境変数を参照することになります。
問題点: クラスが外部の環境変数に直接依存してしまい、これもテストを困難にします。	
インジェクショントークンという仕組みを使います。
アプリケーション起動時にAPIキーなどの設定値をコンテナに登録し、
トークンを使って必要なクラスに注入します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Google Maps APIキーの依存性注入がサポートされ、今後の地図機能の拡張が容易になりました。

* **リファクタリング**
  * GeocodingServiceがAPIキーを直接注入で受け取るように変更され、設定管理が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->