### PR TITLE
renderデプロイエラー対応（versionでpackage.jsonを指定していたことによるbuild出力先にsrcディレクトリが生成…

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,12 +1,11 @@
 import swaggerJSDoc from 'swagger-jsdoc';
-import { version } from '../../package.json';
 
 const options: swaggerJSDoc.Options = {
     definition: {
         openapi: '3.0.3',
         info: {
             title: 'J-Navi Backend(Node.js(Express))',
-            version,
+            version: "1.0.0",
             description: 'A simple CRUD API application made with Express and documented with Swagger',
             license: {
                 name: 'MIT',

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -5,7 +5,7 @@ const options: swaggerJSDoc.Options = {
         openapi: '3.0.3',
         info: {
             title: 'J-Navi Backend(Node.js(Express))',
-            version: "1.0.0",
+            version: process.env.npm_package_version || '1.0.0',
             description: 'A simple CRUD API application made with Express and documented with Swagger',
             license: {
                 name: 'MIT',


### PR DESCRIPTION
…されてしまった
タイトルのとおりです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * SwaggerドキュメントのAPIバージョンを環境変数から動的に設定するように変更し、環境変数がない場合は「1.0.0」を使用します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->