### PR TITLE
pinoのログ出力を警告以上に変更、画像リスト取得のバリデーション内容を見直し

### DIFF
--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,7 +1,7 @@
 import pino from "pino";
 
 const logger = pino({
-    level: process.env.LOG_LEVEL || 'info',
+    level: process.env.LOG_LEVEL || 'warn',
     transport:
         process.env.NODE_ENV !== 'production'
             ? {

--- a/src/middlewares/imageValidation.ts
+++ b/src/middlewares/imageValidation.ts
@@ -89,3 +89,13 @@ export const imageGetValidationRules = [
         .notEmpty().withMessage('画像IDは必須です')
         .isInt().withMessage('画像IDは整数で指定してください')
 ]
+
+/**
+ * 画像リスト取得用のバリデーションルール
+ * リクエストの内容を検証し、適切なエラーメッセージを設定
+ */
+export const imageListGetValidationRules = [
+    param('storeId')
+        .notEmpty().withMessage('店舗IDは必須です')
+        .isInt().withMessage('店舗IDは整数で指定してください')
+]

--- a/src/routes/image.routes.ts
+++ b/src/routes/image.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { ImageController } from "../controllers/imageController"
-import { imageGetValidationRules, imageUpdateValidationRules, imageUploadValidationRules } from "../middlewares/imageValidation"
+import { imageGetValidationRules, imageListGetValidationRules, imageUpdateValidationRules, imageUploadValidationRules } from "../middlewares/imageValidation"
 import { authenticateUser } from "../middlewares/authMiddleware"
 import { handleValidationErrors } from "../middlewares/validationMiddleware"
 import { createHandler } from "../utils/routeHandler"
@@ -90,7 +90,7 @@ imageRouter.post('/', authenticateUser, imageUploadValidationRules, handleValida
  *       '404':
  *         $ref: '#/components/responses/StoreNotFound'
  */
-imageRouter.get(`/`, imageGetValidationRules, handleValidationErrors, createHandler(ImageController, 'getStoreImages'))
+imageRouter.get(`/`, imageListGetValidationRules, handleValidationErrors, createHandler(ImageController, 'getStoreImages'))
 /**
  * @swagger
  * /stores/{storeId}/images/{imageId}:


### PR DESCRIPTION
タイトルの通りです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 画像一覧取得用の新しいバリデーションルールを追加し、`storeId` パラメータの検証が強化されました（未入力や整数でない場合に日本語でエラーメッセージを表示）。

* **その他**
  * デフォルトのログ出力レベルが「info」から「warn」に変更され、警告とエラーのみが標準で表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->