### PR TITLE
fix: セキュリティ監査で検出した認証・認可の脆弱性を修正

### DIFF
--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -2,6 +2,12 @@ import pino from "pino";
 
 const logger = pino({
     level: process.env.LOG_LEVEL || 'warn',
+    /**
+     * pino-http はデフォルトのリクエストシリアライザでヘッダを丸ごと出力する。
+     * LOG_LEVEL を info 以下に下げるとFirebase IDトークンが平文でログに残るため、
+     * 認証情報を含むヘッダはマスクする。
+     */
+    redact: ['req.headers.authorization', 'req.headers.cookie'],
     transport:
         process.env.NODE_ENV !== 'production'
             ? {

--- a/src/controllers/imageController.ts
+++ b/src/controllers/imageController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { ImageService } from "../services/imageService";
 import { StoreImageUploadData } from "../types/image";
-import { getAuthenticatedUserid } from "../utils/auth";
+import { getAuthenticatedUserid, isAdminUser } from "../utils/auth";
 import { autoInjectable } from "tsyringe";
 
 @autoInjectable()
@@ -22,10 +22,13 @@ export class ImageController {
      */
     async uploadStoreImage(req: Request, res: Response): Promise<void> {
 
+        // 投稿者IDはリクエストボディではなく検証済みトークンから取得する（なりすまし防止）
+        const userId = getAuthenticatedUserid(req)
+
         const imageData: StoreImageUploadData = req.body
 
         // サービスを呼び出して画像アップロードを実行
-        const result = await this.imageService.createImage(imageData)
+        const result = await this.imageService.createImage(imageData, userId)
 
         // 正常終了レスポンスをリターン
         res.status(201).json({
@@ -69,6 +72,10 @@ export class ImageController {
 
     async updateStoreImage(req: Request, res: Response) {
 
+        // 操作者の認証情報を取得（投稿者本人か管理者かの判定に使用する）
+        const userId = getAuthenticatedUserid(req)
+        const isAdmin = isAdminUser(req)
+
         // パラメータから店舗IDと画像IDを取得
         const storeId = req.params.storeId
         const imageId = req.params.imageId
@@ -77,7 +84,7 @@ export class ImageController {
         const updateData: StoreImageUploadData = req.body
 
         // サービスクラスから画像IDを条件に画像情報・画像トッピング情報を取得する。
-        const result = await this.imageService.updateStoreImageService(storeId, imageId, updateData)
+        const result = await this.imageService.updateStoreImageService(storeId, imageId, updateData, userId, isAdmin)
 
         res.status(200).json({
             success: true,
@@ -92,14 +99,16 @@ export class ImageController {
 
     async deleteStoreImage(req: Request, res: Response) {
 
+        // 操作者の認証情報を取得（投稿者本人か管理者かの判定に使用する）
         const userId = getAuthenticatedUserid(req)
+        const isAdmin = isAdminUser(req)
 
         // パラメータから店舗IDと画像IDを取得
         const storeId = req.params.storeId
         const imageId = req.params.imageId
 
         // サービスクラスから画像削除処理を実行する
-        const result = await this.imageService.deleteStoreImageService(storeId, imageId, userId)
+        const result = await this.imageService.deleteStoreImageService(storeId, imageId, userId, isAdmin)
 
         res.status(200).json({
             success: true,

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -4,6 +4,7 @@ import { AppError } from "../middlewares/errorMiddleware";
 import { autoInjectable, inject } from "tsyringe";
 import { pinoLogger } from "../di.token";
 import { Logger } from "pino";
+import { getAuthenticatedUserid, isAdminUser } from "../utils/auth";
 
 @autoInjectable()
 export class UserController {
@@ -14,7 +15,11 @@ export class UserController {
     ) { }
 
     async createUser(req: Request, res: Response) {
-        const result = await this.userService.createUser(req.body)
+        // 登録するUIDはリクエストボディではなく検証済みトークンから取得する
+        // （他ユーザーのUID・メールアドレスでのレコード作成を防ぐ）
+        const uid = getAuthenticatedUserid(req)
+
+        const result = await this.userService.createUser({ ...req.body, uid })
         res.status(201).json({
             success: true,
             message: 'ユーザー情報が正常に登録されました',
@@ -31,6 +36,14 @@ export class UserController {
                 endpoint: req.originalUrl
             }, '認証トークンIDが設定されてません')
             throw new AppError('認証トークンIDが設定されてません', 401)
+        }
+
+        // 本人確認：自分以外のユーザー情報は管理者のみ参照できる
+        // （メールアドレス等のPIIが第三者に漏れるのを防ぐ）
+        const requesterUid = getAuthenticatedUserid(req)
+        if (requesterUid !== uid && !isAdminUser(req)) {
+            this.logger?.warn({ requesterUid, uid }, 'ユーザー情報参照権限エラー発生')
+            throw new AppError('このユーザー情報を参照する権限がありません', 403)
         }
 
         const result = await this.userService.getIdToken(uid)

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -49,10 +49,11 @@ export const authenticateUser = async (
             }
         }
 
+        // 既にレスポンスを返しているためnext(error)は呼ばない
+        // （呼ぶとエラーハンドラが二重にレスポンスを送信し ERR_HTTP_HEADERS_SENT が発生する）
         res.status(401).json({
             status: 'InvalidToken',
             message: `無効な認証トークンです`
         })
-        next(error)
     }
 }

--- a/src/middlewares/imageValidation.ts
+++ b/src/middlewares/imageValidation.ts
@@ -9,11 +9,8 @@ const commonImageValidationRules = [
         .notEmpty().withMessage('店舗IDは必須です')
         .isInt().withMessage('店舗IDは整数で指定してください'),
 
-    body('user_id')
-        .notEmpty().withMessage('ユーザーIDは必須です')
-        .isString().withMessage('ユーザーIDは文字列で指定してください')
-        .isLength({ min: 28, max: 28 }).withMessage('ユーザーIDは28文字である必要があります')
-        .matches(/^[a-zA-Z0-9]+$/).withMessage('ユーザーIDは英数字のみが許可されています'),
+    // user_idはリクエストボディからは受け取らない（なりすまし防止）
+    // 投稿者IDは検証済みトークンのUIDをサーバー側で設定する
 
     body('menu_type')
         .notEmpty().withMessage('メニュータイプは必須です')

--- a/src/middlewares/userValidation.ts
+++ b/src/middlewares/userValidation.ts
@@ -1,11 +1,9 @@
 import { body } from "express-validator";
 
 export const userValidationRules = [
-    body('uid')
-        .notEmpty().withMessage('Firebase UIDは必須です')
-        .isLength({ min: 28, max: 28 }).withMessage('Firebase UIDは28文字である必要があります')
-        .matches(/^[a-zA-Z0-9]+$/).withMessage('Firebase UIDは英数字のみが許可されています')
-        .trim(), // サニタイズ: 前後の空白削除
+    // uidはリクエストボディからは受け取らない（他ユーザーのUIDでの登録を防ぐ）
+    // 登録対象のUIDは検証済みトークンのUIDをサーバー側で設定する
+
     body('displayName')
         .optional()
         .isLength({ max: 50 }).withMessage('表示名は50文字以内で入力してください')

--- a/src/middlewares/validation.ts
+++ b/src/middlewares/validation.ts
@@ -1,4 +1,4 @@
-import { body } from 'express-validator';
+import { body, param } from 'express-validator';
 
 /**
  * 店舗情報のバリデーションルール
@@ -50,4 +50,20 @@ export const storeValidationRules = [
     body('topping_calls.*.noodle_type_id')
         .if(body('topping_calls').exists())
         .isInt().withMessage('麺タイプIDは整数で指定してください')
+]
+
+/**
+ * 店舗閉店処理のバリデーションルール
+ * store_nameはテンプレートリテラルで店舗名に直接埋め込まれるため、
+ * 型・長さのチェックを必須とする
+ */
+export const storeCloseValidationRules = [
+    param('id')
+        .notEmpty().withMessage('店舗IDは必須です')
+        .isInt().withMessage('店舗IDは整数で指定してください'),
+
+    body('storeName')
+        .notEmpty().withMessage('店舗名は必須です')
+        .isString().withMessage('店舗名は文字列で指定してください')
+        .isLength({ max: 255 }).withMessage('店舗名は255文字以内で入力してください')
 ]

--- a/src/middlewares/validation.ts
+++ b/src/middlewares/validation.ts
@@ -5,31 +5,74 @@ import { body, param } from 'express-validator';
  * リクエストの内容を検証し、適切なエラーメッセージを設定
  */
 
+// 必須テキスト項目は「型 → 前後の空白除去 → 空判定 → 文字数」の順で検証する。
+// trim() は値を文字列へ強制変換するサニタイザのため、必ず isString() の後に置くこと
+// （先頭に置くと数値・オブジェクトが文字列化されて型チェックをすり抜ける）。
 export const storeValidationRules = [
     body('store_name')
         .notEmpty().withMessage('店舗名は必須です')
+        .isString().withMessage('店舗名は文字列で指定してください')
+        .trim()
+        .notEmpty().withMessage('店舗名は必須です')
         .isLength({ max: 255 }).withMessage('店舗名は255文字以内で入力してください'),
 
+    // 任意項目は optional({ values: 'null' }) で未指定・null を素通しする。
+    // 空文字は「入力なし」としてそのまま許容するため notEmpty() は付けない
+    body('branch_name')
+        .optional({ values: 'null' })
+        .isString().withMessage('支店名は文字列で指定してください')
+        .trim()
+        .isLength({ max: 255 }).withMessage('支店名は255文字以内で入力してください'),
+
     body('address')
+        .notEmpty().withMessage('住所は必須です')
+        .isString().withMessage('住所は文字列で指定してください')
+        .trim()
         .notEmpty().withMessage('住所は必須です')
         .isLength({ max: 255 }).withMessage('住所は255文字以内で入力してください'),
 
     body('business_hours')
         .notEmpty().withMessage('営業時間は必須です')
+        .isString().withMessage('営業時間は文字列で指定してください')
+        .trim()
+        .notEmpty().withMessage('営業時間は必須です')
         .isLength({ max: 255 }).withMessage('営業時間は255文字以内で入力してください'),
 
     body('regular_holidays')
+        .notEmpty().withMessage('定休日は必須です')
+        .isString().withMessage('定休日は文字列で指定してください')
+        .trim()
         .notEmpty().withMessage('定休日は必須です')
         .isLength({ max: 255 }).withMessage('定休日は255文字以内で入力してください'),
 
     body('prior_meal_voucher')
         .isBoolean().withMessage('事前食券購入の有無は真偽値で指定してください'),
 
+    // topping_details / call_details / lot_detail は DB 側が Text 型で上限を持たないため、
+    // 自由記述欄として妥当な 1000 文字をアプリ側の上限とする
+    body('topping_details')
+        .optional({ values: 'null' })
+        .isString().withMessage('トッピング詳細は文字列で指定してください')
+        .trim()
+        .isLength({ max: 1000 }).withMessage('トッピング詳細は1000文字以内で入力してください'),
+
+    body('call_details')
+        .optional({ values: 'null' })
+        .isString().withMessage('コール詳細は文字列で指定してください')
+        .trim()
+        .isLength({ max: 1000 }).withMessage('コール詳細は1000文字以内で入力してください'),
+
     body('is_all_increased')
         .isBoolean().withMessage('全マシの有無は真偽値で指定してください'),
 
     body('is_lot')
         .isBoolean().withMessage('ロット制の有無は真偽値で指定してください'),
+
+    body('lot_detail')
+        .optional({ values: 'null' })
+        .isString().withMessage('ロット制詳細は文字列で指定してください')
+        .trim()
+        .isLength({ max: 1000 }).withMessage('ロット制詳細は1000文字以内で入力してください'),
 
     body('topping_calls')
         .optional()
@@ -62,8 +105,13 @@ export const storeCloseValidationRules = [
         .notEmpty().withMessage('店舗IDは必須です')
         .isInt().withMessage('店舗IDは整数で指定してください'),
 
+    // 検証順序の意図は storeValidationRules の冒頭コメントを参照。
+    // ここは値が「【閉店】${storeName}」に埋め込まれるため、
+    // 型チェックが漏れると {} が「【閉店】[object Object]」として登録される
     body('storeName')
         .notEmpty().withMessage('店舗名は必須です')
         .isString().withMessage('店舗名は文字列で指定してください')
+        .trim()
+        .notEmpty().withMessage('店舗名は必須です')
         .isLength({ max: 255 }).withMessage('店舗名は255文字以内で入力してください')
 ]

--- a/src/routes/store.routes.ts
+++ b/src/routes/store.routes.ts
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { StoreController } from "../controllers/storeController";
-import { storeValidationRules } from "../middlewares/validation";
+import { storeCloseValidationRules, storeValidationRules } from "../middlewares/validation";
 import { createHandler } from "../utils/routeHandler";
 import { handleValidationErrors } from "../middlewares/validationMiddleware";
+import { authenticateUser } from "../middlewares/authMiddleware";
 
 const storeRouter = Router()
 
@@ -13,7 +14,9 @@ const storeRouter = Router()
  *     tags:
  *       - Stores
  *     summary: 新規店舗登録
- *     description: 新しい店舗情報を登録します。住所から緯度経度を自動計算して保存します。
+ *     description: 新しい店舗情報を登録します。住所から緯度経度を自動計算して保存します。認証が必要です。
+ *     security:
+ *       - bearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -35,10 +38,12 @@ const storeRouter = Router()
  *                   $ref: '#/components/schemas/Store'
  *       '400':
  *         description: リクエストが無効です。
+ *       '401':
+ *         description: 認証トークンが無効、または設定されていません。
  *       '500':
  *         description: サーバーエラー。
  */
-storeRouter.post('/', storeValidationRules, handleValidationErrors, createHandler(StoreController, "createStore"))
+storeRouter.post('/', authenticateUser, storeValidationRules, handleValidationErrors, createHandler(StoreController, "createStore"))
 
 /**
  * @swagger
@@ -106,7 +111,9 @@ storeRouter.get('/', createHandler(StoreController, 'getStoresAll'))
  *     tags:
  *       - Stores
  *     summary: 店舗情報更新
- *     description: 指定されたIDの店舗情報を更新します。
+ *     description: 指定されたIDの店舗情報を更新します。認証が必要です。
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -135,10 +142,12 @@ storeRouter.get('/', createHandler(StoreController, 'getStoresAll'))
  *                   $ref: '#/components/schemas/Store'
  *       '400':
  *         description: リクエストが無効です。
+ *       '401':
+ *         description: 認証トークンが無効、または設定されていません。
  *       '404':
  *         $ref: '#/components/responses/StoreNotFound'
  */
-storeRouter.put('/:id', storeValidationRules, handleValidationErrors, createHandler(StoreController, 'updateStore'))
+storeRouter.put('/:id', authenticateUser, storeValidationRules, handleValidationErrors, createHandler(StoreController, 'updateStore'))
 
 /**
  * @swagger
@@ -147,7 +156,9 @@ storeRouter.put('/:id', storeValidationRules, handleValidationErrors, createHand
  *     tags:
  *       - Stores
  *     summary: 店舗を閉店済みにする
- *     description: 指定された店舗の営業状態を「閉店」に変更します。
+ *     description: 指定された店舗の営業状態を「閉店」に変更します。認証が必要です。
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -155,6 +166,19 @@ storeRouter.put('/:id', storeValidationRules, handleValidationErrors, createHand
  *         schema:
  *           type: integer
  *         description: 店舗ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - storeName
+ *             properties:
+ *               storeName:
+ *                 type: string
+ *                 maxLength: 255
+ *                 description: 閉店表示に使用する店舗名
  *     responses:
  *       '200':
  *         description: 正常に店舗を閉店済みにしました。
@@ -166,10 +190,14 @@ storeRouter.put('/:id', storeValidationRules, handleValidationErrors, createHand
  *                 success:
  *                   type: boolean
  *                   example: true
+ *       '400':
+ *         description: リクエストが無効です。
+ *       '401':
+ *         description: 認証トークンが無効、または設定されていません。
  *       '404':
  *         $ref: '#/components/responses/StoreNotFound'
  */
-storeRouter.patch('/:id/close', createHandler(StoreController, 'storeClose'))
+storeRouter.patch('/:id/close', authenticateUser, storeCloseValidationRules, handleValidationErrors, createHandler(StoreController, 'storeClose'))
 
 /**
  * @swagger

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -50,6 +50,7 @@ userRouter.post(`/`, authenticateUser, userValidationRules, handleValidationErro
  * /users/{uid}:
  *   get:
  *     summary: ユーザー情報の取得
+ *     description: 指定されたUIDのユーザー情報を取得します。本人、または管理者ロールを持つユーザーのみ参照できます。
  *     tags: [Users]
  *     security:
  *       - bearerAuth: []
@@ -69,6 +70,8 @@ userRouter.post(`/`, authenticateUser, userValidationRules, handleValidationErro
  *               $ref: '#/components/schemas/User'
  *       '401':
  *         description: 認証エラー
+ *       '403':
+ *         description: 他ユーザーの情報を参照する権限がありません
  *       '404':
  *         description: ユーザーが見つかりません
  *       '500':

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -10,6 +10,20 @@ import { Logger } from "pino";
 @injectable()
 export class ImageService {
 
+    /**
+     * Firebase Storageへの保存を許可する画像MIMEタイプと、対応する拡張子
+     *
+     * Storageに設定したContent-Typeは公開URL（storage.googleapis.com）で
+     * そのまま配信されるため、text/html等を保存させてはならない。
+     * 拡張子の判定と許可判定を同じ表から導くことで、両者の乖離を防ぐ
+     */
+    private static readonly ALLOWED_IMAGE_MIME_TYPES: Readonly<Record<string, string>> = {
+        'image/jpeg': '.jpg',
+        'image/png': '.png',
+        'image/gif': '.gif',
+        'image/webp': '.webp'
+    }
+
     constructor(
         @inject(PRISMA_CLIENT) private prisma: PrismaClient,
         @inject(pinoLogger) private logger: Logger
@@ -26,7 +40,7 @@ export class ImageService {
         // StorageへのアップロードはネットワークI/OのためDBトランザクションの外で行う。
         // トランザクション内で実行すると、アップロードの所要時間だけDB接続とロックを占有し、
         // PRISMA_TRANSACTION_TIMEOUT超過でロールバックする可能性がある
-        const uploadedUrl = await this.uploadImageToStorage(data.image_base64!, data.store_id)
+        const uploadedUrl = await this.uploadImageToStorage(data.image_base64, data.store_id)
 
         try {
             // トランザクションで処理することで、データの整合性を担保
@@ -379,9 +393,16 @@ export class ImageService {
      * @param imageBase64 data URL形式のBase64画像データ
      * @param storeId 保存先の店舗ID
      * @returns アップロードしたファイルの公開URL
-     * @throws AppError 画像データ形式が不正な場合は400
+     * @throws AppError 画像データが未設定、または形式が不正な場合は400
      */
-    private async uploadImageToStorage(imageBase64: string, storeId: string | number): Promise<string> {
+    private async uploadImageToStorage(imageBase64: string | null | undefined, storeId: string | number): Promise<string> {
+        // 未設定チェック。呼び出し側でnon-nullアサーションを使うと、
+        // 万一バリデーションを通過した場合にTypeErrorとなり500を返してしまう
+        if (!imageBase64) {
+            this.logger.error({ storeId }, '画像データ未設定エラー発生')
+            throw new AppError('画像データは必須です', 400)
+        }
+
         // Base64画像データをバッファに変換
         const matches = imageBase64.match(/^data:([A-Za-z-+/]+);base64,(.+)$/)
         if (!matches || matches.length !== 3) {
@@ -392,8 +413,13 @@ export class ImageService {
         const imageBuffer = Buffer.from(matches[2], 'base64')
         const contentType = matches[1]
 
-        // MIMEタイプから拡張子を取得
-        const fileExtension = this.getFileExtensionFromMimeType(contentType)
+        // MIMEタイプを許可リストで検証し、対応する拡張子を得る。
+        // 正規表現は image/svg+xml や text/html も通してしまうため、ここで弾く
+        const fileExtension = ImageService.ALLOWED_IMAGE_MIME_TYPES[contentType]
+        if (!fileExtension) {
+            this.logger.error({ storeId, contentType }, '非対応画像形式エラー発生')
+            throw new AppError('対応していない画像形式です。JPEG、PNG、GIF、WEBPのみ利用できます', 400)
+        }
 
         // ファイルパスの生成（UUID + タイムスタンプで一意性を確保）
         const timestamp = Date.now()
@@ -493,26 +519,6 @@ export class ImageService {
         if (image.user_id !== userId) {
             this.logger.warn({ storeId, imageId, userId }, '画像操作権限エラー発生')
             throw new AppError('この画像を操作する権限がありません', 403)
-        }
-    }
-
-    /**
-     * MIMEタイプからファイル拡張子を取得する
-     * @param mimeType MIMEタイプ
-     * @returns 対応するファイル拡張子
-     */
-    private getFileExtensionFromMimeType(mineType: string): string {
-        switch (mineType) {
-            case 'image/jpeg':
-                return '.jpg'
-            case 'image/png':
-                return '.png'
-            case 'image/gif':
-                return '.gif'
-            case 'image/webp':
-                return '.webp'
-            default:
-                return '.jpg'
         }
     }
 }

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -19,9 +19,10 @@ export class ImageService {
    * 店舗画像とそれに関連するトッピング情報を登録する
    * 画像はBase64形式でエンコードされている必要がある
    * @param data 店舗画像のアップロードデータ
+   * @param userId 投稿者のFirebase UID（検証済みトークン由来）
    * @returns 作成された画像エントリ
    */
-    async createImage(data: StoreImageUploadData) {
+    async createImage(data: StoreImageUploadData, userId: string) {
         // トランザクションで処理することで、データの整合性を担保
         return await this.prisma.$transaction(async (tx) => {
             // Base64画像データをバッファに変換
@@ -64,7 +65,7 @@ export class ImageService {
             const image = await tx.image.create({
                 data: {
                     store_id: BigInt(data.store_id),
-                    user_id: data.user_id,
+                    user_id: userId,
                     menu_type: data.menu_type,
                     menu_name: data.menu_name,
                     image_url: publicUrl
@@ -202,11 +203,20 @@ export class ImageService {
         return editData
     }
 
-    async updateStoreImageService(storeId: string | number, imageId: string | number, data: StoreImageUploadData) {
+    async updateStoreImageService(
+        storeId: string | number,
+        imageId: string | number,
+        data: StoreImageUploadData,
+        userId: string,
+        isAdmin: boolean = false
+    ) {
         return await this.prisma.$transaction(async (tx) => {
             // パラメータをBigIntに変換
             const storeBigInt = BigInt(storeId)
             const imageBigInt = BigInt(imageId)
+
+            // 画像所有者チェック（投稿者本人、または管理者のみ更新可）
+            await this.validateImageOwnership(tx, storeBigInt, imageBigInt, userId, isAdmin)
 
             // 現在の画像情報を取得（旧画像URL取得のため）
             const currentImage = await this.validateImageExists(tx, storeBigInt, imageBigInt)
@@ -229,8 +239,9 @@ export class ImageService {
                 const fileExtension = this.getFileExtensionFromMimeType(contentType)
 
                 // 新しいファイルパスの生成（UUID + タイムスタンプで一意性を確保）
+                // 保存先はボディのstore_idではなく、認可判定に使ったパスパラメータのstoreIdを使用する
                 const timestamp = Date.now()
-                const fileName = `stores/${data.store_id}/${uuidv4()}_${timestamp}${fileExtension}`
+                const fileName = `stores/${storeId}/${uuidv4()}_${timestamp}${fileExtension}`
 
                 // FireBase Storageに新しい画像をアップロード
                 const file = bucket.file(fileName)
@@ -305,15 +316,20 @@ export class ImageService {
      * @returns 削除された画像情報
      */
 
-    async deleteStoreImageService(storeId: string | number, imageId: string | number, userId: string) {
+    async deleteStoreImageService(
+        storeId: string | number,
+        imageId: string | number,
+        userId: string,
+        isAdmin: boolean = false
+    ) {
         // パラメータをBigIntに変換
         const storeBigInt = BigInt(storeId)
         const imageBigInt = BigInt(imageId)
 
         // 画像存在確認（共通処理）
         const currentImage = await this.prisma.$transaction(async (tx) => {
-            // 画像所有者チェック
-            await this.validateImageOwnership(tx, storeBigInt, imageBigInt, userId)
+            // 画像所有者チェック（投稿者本人、または管理者のみ削除可）
+            await this.validateImageOwnership(tx, storeBigInt, imageBigInt, userId, isAdmin)
             // 画像存在確認（共通処理）
             return await this.validateImageExists(tx, storeBigInt, imageBigInt)
         })
@@ -413,11 +429,22 @@ export class ImageService {
         }
     }
 
+    /**
+     * 画像の操作権限を検証する（共通処理）
+     * 投稿者本人、または管理者ロール保持者のみ操作を許可する
+     * @param tx Prismaトランザクション
+     * @param storeId 店舗ID（BigInt）
+     * @param imageId 画像ID（BigInt）
+     * @param userId 操作者のFirebase UID（検証済みトークン由来）
+     * @param isAdmin 操作者が管理者ロールを持つ場合true
+     * @throws AppError 画像が存在しない場合は404、権限が無い場合は403
+     */
     private async validateImageOwnership(
         tx: Prisma.TransactionClient,
         storeId: bigint,
         imageId: bigint,
-        userId: string
+        userId: string,
+        isAdmin: boolean = false
     ): Promise<void> {
         const image = await tx.image.findFirst({
             where: { id: imageId, store_id: storeId },
@@ -428,7 +455,14 @@ export class ImageService {
             this.logger.error({ storeId, imageId }, '指定画像未存在エラー発生')
             throw new AppError('指定された画像情報が存在しません', 404)
         }
-        if (image.user_id !== userId) throw new AppError('この画像を削除する権限がありません', 403)
+
+        // 管理者はモデレーション目的で他ユーザーの画像も操作できる
+        if (isAdmin) return
+
+        if (image.user_id !== userId) {
+            this.logger.warn({ storeId, imageId, userId }, '画像操作権限エラー発生')
+            throw new AppError('この画像を操作する権限がありません', 403)
+        }
     }
 
     /**

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -23,74 +23,49 @@ export class ImageService {
    * @returns 作成された画像エントリ
    */
     async createImage(data: StoreImageUploadData, userId: string) {
-        // トランザクションで処理することで、データの整合性を担保
-        return await this.prisma.$transaction(async (tx) => {
-            // Base64画像データをバッファに変換
-            const matches = data.image_base64!.match(/^data:([A-Za-z-+/]+);base64,(.+)$/)
-            if (!matches || matches.length !== 3) {
-                this.logger.error({ matches }, '不正画像データエラー発生')
-                throw new Error('無効な画像データ形式です');
-            }
+        // StorageへのアップロードはネットワークI/OのためDBトランザクションの外で行う。
+        // トランザクション内で実行すると、アップロードの所要時間だけDB接続とロックを占有し、
+        // PRISMA_TRANSACTION_TIMEOUT超過でロールバックする可能性がある
+        const uploadedUrl = await this.uploadImageToStorage(data.image_base64!, data.store_id)
 
-            const imageBuffer = Buffer.from(matches[2], 'base64')
-            const contentType = matches[1]
+        try {
+            // トランザクションで処理することで、データの整合性を担保
+            return await this.prisma.$transaction(async (tx) => {
+                // データベースに画像情報を保存
+                const image = await tx.image.create({
+                    data: {
+                        store_id: BigInt(data.store_id),
+                        user_id: userId,
+                        menu_type: data.menu_type,
+                        menu_name: data.menu_name,
+                        image_url: uploadedUrl
+                    }
+                })
 
-            // MIMEタイプから拡張子を取得
-            const fileExtension = this.getFileExtensionFromMimeType(contentType)
+                // トッピング選択がある場合は関連付けを作成
+                const imageStoreToppingCalls = []
 
-            // ファイルパスの生成（UUID + タイムスタンプで一意性を確保）
-            const timestamp = Date.now()
-            const fileName = `stores/${data.store_id}/${uuidv4()}_${timestamp}${fileExtension}`
+                if (data.topping_selections && data.topping_selections.length > 0) {
+                    for (const selection of data.topping_selections) {
+                        // 画像トッピングコール情報を保存し、トッピングを関連付ける
+                        const imageToppingCall = await tx.imageStoreToppingCall.create({
+                            data: {
+                                image_id: BigInt(image.id),
+                                topping_id: BigInt(selection.topping_id),
+                                store_topping_call_id: BigInt(selection.store_topping_call_id)
+                            }
+                        })
+                        imageStoreToppingCalls.push(imageToppingCall)
 
-            // FireBase Storageにアップロード
-            const file = bucket.file(fileName)
-
-            // ファイル書き込む
-            await file.save(imageBuffer, {
-                metadata: {
-                    contentType,
-                    metadata: {
-                        storeId: String(data.store_id)
                     }
                 }
+                return { image, imageStoreToppingCalls }
             })
-
-            // ファイルの公開URL取得のためのアクセス設定
-            await file.makePublic();
-
-            // 公開URLの取得
-            const publicUrl = `https://storage.googleapis.com/${bucket.name}/${fileName}`;
-
-            // データベースに画像情報を保存
-            const image = await tx.image.create({
-                data: {
-                    store_id: BigInt(data.store_id),
-                    user_id: userId,
-                    menu_type: data.menu_type,
-                    menu_name: data.menu_name,
-                    image_url: publicUrl
-                }
-            })
-
-            // トッピング選択がある場合は関連付けを作成
-            const imageStoreToppingCalls = []
-
-            if (data.topping_selections && data.topping_selections.length > 0) {
-                for (const selection of data.topping_selections) {
-                    // 画像トッピングコール情報を保存し、トッピングを関連付ける
-                    const imageToppingCall = await tx.imageStoreToppingCall.create({
-                        data: {
-                            image_id: BigInt(image.id),
-                            topping_id: BigInt(selection.topping_id),
-                            store_topping_call_id: BigInt(selection.store_topping_call_id)
-                        }
-                    })
-                    imageStoreToppingCalls.push(imageToppingCall)
-
-                }
-            }
-            return { image, imageStoreToppingCalls }
-        })
+        } catch (error) {
+            // 補償処理：DB登録に失敗した場合、アップロード済みファイルが孤立するため削除する
+            await this.safeDeleteImageFromStorage(uploadedUrl, '画像登録失敗の補償処理')
+            throw error
+        }
     }
 
     /**
@@ -203,6 +178,21 @@ export class ImageService {
         return editData
     }
 
+    /**
+     * 店舗画像を更新する
+     *
+     * StorageとDBは同一のトランザクションで保護できないため、
+     * 「認可 → アップロード → DB更新 → 旧ファイル削除」の順に段階を分け、
+     * DB更新が失敗した場合はアップロード済みファイルを削除する補償処理で整合性を保つ。
+     * 旧ファイルの削除は必ずコミット後に行う。コミット前に削除すると、
+     * DB更新が失敗した際にレコードは旧URLを指したままファイルだけが失われる
+     * @param storeId 店舗ID（パスパラメータ）
+     * @param imageId 画像ID（パスパラメータ）
+     * @param data 更新内容
+     * @param userId 操作者のFirebase UID（検証済みトークン由来）
+     * @param isAdmin 操作者が管理者ロールを持つ場合true
+     * @returns 更新された画像情報
+     */
     async updateStoreImageService(
         storeId: string | number,
         imageId: string | number,
@@ -210,102 +200,89 @@ export class ImageService {
         userId: string,
         isAdmin: boolean = false
     ) {
-        return await this.prisma.$transaction(async (tx) => {
-            // パラメータをBigIntに変換
-            const storeBigInt = BigInt(storeId)
-            const imageBigInt = BigInt(imageId)
+        // パラメータをBigIntに変換
+        const storeBigInt = BigInt(storeId)
+        const imageBigInt = BigInt(imageId)
 
+        // 【第1段階】認可と存在確認のみを短いトランザクションで実施する。
+        // アップロードより先に行うことで、権限の無い利用者にStorageへ書き込ませない
+        await this.prisma.$transaction(async (tx) => {
             // 画像所有者チェック（投稿者本人、または管理者のみ更新可）
             await this.validateImageOwnership(tx, storeBigInt, imageBigInt, userId, isAdmin)
+            await this.validateImageExists(tx, storeBigInt, imageBigInt)
+        })
 
-            // 現在の画像情報を取得（旧画像URL取得のため）
-            const currentImage = await this.validateImageExists(tx, storeBigInt, imageBigInt)
+        // 【第2段階】新しい画像をトランザクション外でアップロードする。
+        // 保存先はボディのstore_idではなく、認可判定に使ったパスパラメータのstoreIdを使用する
+        const uploadedUrl = data.image_base64
+            ? await this.uploadImageToStorage(data.image_base64, storeId)
+            : null
 
-            let newImageUrl = currentImage.image_url    // デフォルトは現在のURL
+        // 【第3段階】DBを更新する
+        let txResult
+        try {
+            txResult = await this.prisma.$transaction(async (tx) => {
+                // 第1段階からの経過中に所有者や存在状態が変化している可能性があるため再検証する
+                await this.validateImageOwnership(tx, storeBigInt, imageBigInt, userId, isAdmin)
 
-            // image_base64が提供された場合のFirebase Storage処理
-            if (data.image_base64) {
-                // Base64画像データをバッファに変換
-                const matches = data.image_base64.match(/^data:([A-Za-z-+/]+);base64,(.+)$/)
-                if (!matches || matches.length !== 3) {
-                    this.logger.error({ matches }, '不正画像データエラー発生')
-                    throw new AppError('無効な画像データ形式です', 400)
-                }
+                // 置き換え直前の状態をトランザクション内で読み直す。
+                // 第1段階で取得した値を使うと、並行更新があった場合に古いURLで上書きしてしまう
+                const before = await this.validateImageExists(tx, storeBigInt, imageBigInt)
 
-                const imageBuffer = Buffer.from(matches[2], 'base64')
-                const contentType = matches[1]
-
-                // MIMEタイプから拡張子を取得
-                const fileExtension = this.getFileExtensionFromMimeType(contentType)
-
-                // 新しいファイルパスの生成（UUID + タイムスタンプで一意性を確保）
-                // 保存先はボディのstore_idではなく、認可判定に使ったパスパラメータのstoreIdを使用する
-                const timestamp = Date.now()
-                const fileName = `stores/${storeId}/${uuidv4()}_${timestamp}${fileExtension}`
-
-                // FireBase Storageに新しい画像をアップロード
-                const file = bucket.file(fileName)
-
-                // ファイルを書き込む
-                await file.save(imageBuffer, {
-                    metadata: {
-                        contentType,
-                        metadata: {
-                            storeId: String(storeId)
-                        }
+                // imagesテーブルの更新
+                const updatedImage = await tx.image.update({
+                    where: {
+                        id: imageBigInt
+                    },
+                    data: {
+                        menu_type: data.menu_type,
+                        menu_name: data.menu_name,
+                        image_url: uploadedUrl ?? before.image_url
                     }
                 })
-                // ファイルの公開URL取得のためのアクセス設定
-                await file.makePublic()
 
-                // 新しい公開URLの取得
-                newImageUrl = `https://storage.googleapis.com/${bucket.name}/${fileName}`
+                // 既存のimage_store_topping_callsを削除
+                await this.deleteImageToppingCalls(tx, imageBigInt)
 
-                // 旧画像をFirebase Storageから削除（共通処理）
-                try {
-                    await this.deleteImageFromStorage(currentImage.image_url)
-                } catch (deleteError) {
-                    // 旧画像の削除に失敗してもメイン処理は継続する
-                    this.logger.warn({ deleteError }, 'Firebase Storage 画像削除失敗')
+                // 新しいトッピング選択を挿入
+                const imageStoreToppingCalls = []
+                if (data.topping_selections && data.topping_selections.length > 0) {
+                    for (const selection of data.topping_selections) {
+                        const imageToppingCall = await tx.imageStoreToppingCall.create({
+                            data: {
+                                image_id: imageBigInt,
+                                topping_id: BigInt(selection.topping_id),
+                                store_topping_call_id: BigInt(selection.store_topping_call_id)
+                            }
+                        })
+                        imageStoreToppingCalls.push(imageToppingCall)
+                    }
                 }
-            }
 
-            // imagesテーブルの更新
-            const updatedImage = await tx.image.update({
-                where: {
-                    id: imageBigInt
-                },
-                data: {
-                    menu_type: data.menu_type,
-                    menu_name: data.menu_name,
-                    image_url: newImageUrl
+                return {
+                    image: updatedImage,
+                    imageStoreToppingCalls,
+                    imageUpdated: uploadedUrl !== null,
+                    // コミット後に削除する対象。実際に置き換えたURLだけを消す
+                    replacedUrl: before.image_url
                 }
             })
-
-            // 既存のimage_store_topping_callsを削除
-            await this.deleteImageToppingCalls(tx, imageBigInt)
-
-            // 新しいトッピング選択を挿入
-            const imageStoreToppingCalls = []
-            if (data.topping_selections && data.topping_selections.length > 0) {
-                for (const selection of data.topping_selections) {
-                    const imageToppingCall = await tx.imageStoreToppingCall.create({
-                        data: {
-                            image_id: imageBigInt,
-                            topping_id: BigInt(selection.topping_id),
-                            store_topping_call_id: BigInt(selection.store_topping_call_id)
-                        }
-                    })
-                    imageStoreToppingCalls.push(imageToppingCall)
-                }
+        } catch (error) {
+            // 補償処理：DB更新に失敗した場合、アップロード済みファイルが孤立するため削除する
+            if (uploadedUrl) {
+                await this.safeDeleteImageFromStorage(uploadedUrl, '画像更新失敗の補償処理')
             }
+            throw error
+        }
 
-            return {
-                image: updatedImage,
-                imageStoreToppingCalls,
-                imageUpdated: data.image_base64 ? true : false
-            }
-        })
+        // 【第4段階】コミット後に旧ファイルを削除する。
+        // ここでの失敗は孤立ファイルが残るだけでDBとの不整合は起きない
+        const { replacedUrl, ...result } = txResult
+        if (uploadedUrl && replacedUrl !== uploadedUrl) {
+            await this.safeDeleteImageFromStorage(replacedUrl, '更新による旧画像削除')
+        }
+
+        return result
     }
 
     /**
@@ -326,33 +303,27 @@ export class ImageService {
         const storeBigInt = BigInt(storeId)
         const imageBigInt = BigInt(imageId)
 
-        // 画像存在確認（共通処理）
-        const currentImage = await this.prisma.$transaction(async (tx) => {
-            // 画像所有者チェック（投稿者本人、または管理者のみ削除可）
-            await this.validateImageOwnership(tx, storeBigInt, imageBigInt, userId, isAdmin)
-            // 画像存在確認（共通処理）
-            return await this.validateImageExists(tx, storeBigInt, imageBigInt)
-        })
-
-        // Firebase Storageから画像ファイルを削除（共通処理）
-        try {
-            await this.deleteImageFromStorage(currentImage.image_url)
-        } catch (deleteError) {
-            // Firebase Storageの削除に失敗してもメイン処理は継続する
-            this.logger.warn({ deleteError }, 'Firebase Storage 画像削除失敗')
-        }
-
-        // imagesテーブルから画像情報を削除
+        // 認可・関連レコード削除・画像レコード削除を1つのトランザクションで完結させる。
+        // 分割すると、DB削除が失敗したときにファイルだけが失われてリンク切れになる
         const deleteImage = await this.prisma.$transaction(async (tx) => {
+            // 画像所有者チェック（投稿者本人、または管理者のみ削除可）
+            // 存在確認も兼ねており、対象が無ければ404を送出する
+            await this.validateImageOwnership(tx, storeBigInt, imageBigInt, userId, isAdmin)
+
             // 関連するimage_store_topping_callsを削除（共通処理）
             await this.deleteImageToppingCalls(tx, imageBigInt)
 
+            // 削除結果から image_url を受け取り、コミット後のStorage削除に使う
             return await tx.image.delete({
                 where: {
                     id: imageBigInt
                 }
             })
         })
+
+        // コミット後にFirebase Storageの実ファイルを削除する。
+        // ここでの失敗は孤立ファイルが残るだけでDBとの不整合は起きない
+        await this.safeDeleteImageFromStorage(deleteImage.image_url, '画像削除')
 
         return {
             image: deleteImage,
@@ -400,6 +371,66 @@ export class ImageService {
                 image_id: imageId
             }
         })
+    }
+
+    /**
+     * Base64画像をFirebase Storageへアップロードし、公開URLを返す（共通処理）
+     * ネットワークI/Oを含むため、DBトランザクションの外から呼び出すこと
+     * @param imageBase64 data URL形式のBase64画像データ
+     * @param storeId 保存先の店舗ID
+     * @returns アップロードしたファイルの公開URL
+     * @throws AppError 画像データ形式が不正な場合は400
+     */
+    private async uploadImageToStorage(imageBase64: string, storeId: string | number): Promise<string> {
+        // Base64画像データをバッファに変換
+        const matches = imageBase64.match(/^data:([A-Za-z-+/]+);base64,(.+)$/)
+        if (!matches || matches.length !== 3) {
+            this.logger.error({ storeId }, '不正画像データエラー発生')
+            throw new AppError('無効な画像データ形式です', 400)
+        }
+
+        const imageBuffer = Buffer.from(matches[2], 'base64')
+        const contentType = matches[1]
+
+        // MIMEタイプから拡張子を取得
+        const fileExtension = this.getFileExtensionFromMimeType(contentType)
+
+        // ファイルパスの生成（UUID + タイムスタンプで一意性を確保）
+        const timestamp = Date.now()
+        const fileName = `stores/${storeId}/${uuidv4()}_${timestamp}${fileExtension}`
+
+        // FireBase Storageにアップロード
+        const file = bucket.file(fileName)
+
+        // ファイルを書き込む
+        await file.save(imageBuffer, {
+            metadata: {
+                contentType,
+                metadata: {
+                    storeId: String(storeId)
+                }
+            }
+        })
+
+        // ファイルの公開URL取得のためのアクセス設定
+        await file.makePublic()
+
+        // 公開URLの取得
+        return `https://storage.googleapis.com/${bucket.name}/${fileName}`
+    }
+
+    /**
+     * Firebase Storageの画像を削除し、失敗しても例外を送出しない（共通処理）
+     * 削除失敗は孤立ファイルが残るだけでDBとの整合性は壊れないため、警告ログに留める
+     * @param imageUrl 削除対象の画像URL
+     * @param context 呼び出し文脈（ログ調査用）
+     */
+    private async safeDeleteImageFromStorage(imageUrl: string, context: string): Promise<void> {
+        try {
+            await this.deleteImageFromStorage(imageUrl)
+        } catch (deleteError) {
+            this.logger.warn({ deleteError, imageUrl, context }, 'Firebase Storage 画像削除失敗')
+        }
     }
 
     /**

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -69,7 +69,7 @@ import { Image, ImageStoreToppingCall } from "@prisma/client";
 // StoreImageUploadData インターフェースの追加
 export interface StoreImageUploadData {
     store_id: number | string;
-    user_id: string;
+    // user_idは含めない。投稿者IDは検証済みトークンのUIDをサーバー側で設定する
     menu_type: number;
     menu_name: string;
     image_base64: string | null;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,15 +1,32 @@
 import { Request } from "express"
+import { AppError } from "../middlewares/errorMiddleware"
 
+/**
+ * 認証済みユーザーのFirebase UIDを取得する
+ * リクエストボディのIDではなく、必ず検証済みトークンのUIDを信頼の起点とする
+ * @param req リクエストオブジェクト
+ * @returns Firebase UID
+ * @throws AppError 認証情報が存在しない場合
+ */
 export const getAuthenticatedUserid = (req: Request): string => {
     // 認証チェック
     if (!req.user) {
-        throw new Error('画像削除するには認証が必要です。')
+        throw new AppError('この操作を行うには認証が必要です', 401)
     }
 
     // 認証チェック - ユーザーIDの存在確認
     if (!req.user.uid) {
-        throw new Error('画像削除するには有効な認証情報が必要です')
+        throw new AppError('この操作を行うには有効な認証情報が必要です', 401)
     }
 
     return req.user.uid
 }
+
+/**
+ * 認証済みユーザーが管理者ロールを持つかを判定する
+ * 管理者権限はFirebase Authenticationのカスタムクレーム（admin: true）で付与する
+ * 付与例: admin.auth().setCustomUserClaims(uid, { admin: true })
+ * @param req リクエストオブジェクト
+ * @returns 管理者の場合true
+ */
+export const isAdminUser = (req: Request): boolean => req.user?.admin === true


### PR DESCRIPTION
コードベース全体のセキュリティ監査で検出した認証・認可の不備を修正しました。あわせてレビュー指摘に対応しています。

## 認可モデル

| リソース | 操作 | 権限 |
|---|---|---|
| 店舗 | 参照（GET） | 誰でも可（変更なし） |
| 店舗 | 登録・更新・閉店 | ログイン済みユーザー |
| 画像 | 参照（GET） | 誰でも可（変更なし） |
| 画像 | 投稿（POST） | ログイン済みユーザー（投稿者＝トークンのUID） |
| 画像 | 更新・削除 | 投稿者本人 または 管理者 |
| ユーザー | 参照（GET） | 本人 または 管理者 |
| ユーザー | 登録（POST） | ログイン済みユーザー（UID＝トークンのUID） |

管理者ロールは Firebase Authentication のカスタムクレームで判定します。付与は Admin SDK 側で行ってください。

```ts
await admin.auth().setCustomUserClaims(uid, { admin: true })
```

## 修正した脆弱性

### 1. 店舗APIが完全に未認証（HIGH・認証バイパス）

`POST /stores`、`PUT /stores/:id`、`PATCH /stores/:id/close` のいずれにも `authenticateUser` が適用されていませんでした。他のルータでは一貫して適用されていたため、適用漏れです。

未認証の第三者が `GET /stores` で店舗IDを列挙し、全店舗の名称・住所・営業時間を改ざんできる状態でした。さらに `updateStore` は `storeToppingCall.deleteMany` を実行するため、リクエストに `topping_calls` を含めなければトッピングコール設定が復元されず永久に失われます。

`PATCH /stores/:id/close` はバリデーションルールすら適用されておらず、`store_name` がテンプレートリテラルで直接組み立てられていたため、型・長さのチェックを受けずに書き換え可能でした。`storeCloseValidationRules` を新設して適用しています。

### 2. 画像更新APIに所有者チェックが無い（HIGH・IDOR）

`updateStoreImageService` は存在確認（`validateImageExists`）のみで、削除処理にある `validateImageOwnership` を呼んでいませんでした。コントローラも `getAuthenticatedUserid` を呼んでおらず、認証済みUIDがサービスに渡っていませんでした。

任意のログインユーザーが他人の画像を上書きでき、同時に `deleteImageFromStorage` により元画像ファイルが Firebase Storage から削除される状態でした。

### 3. ユーザー情報取得に本人確認が無い（HIGH・PII漏洩）

`GET /users/:uid` は `req.params.uid` と `req.user.uid` を照合しておらず、`getIdToken` が `select` 指定なしで全カラムを返すため、任意ユーザーのメールアドレス・表示名・bio が取得可能でした。UIDは未認証の `GET /stores/:storeId/images` のレスポンスから列挙できるため、全ユーザーのメールアドレス一覧を作成できる状態でした。

### 4. リクエストボディのIDを信用（MEDIUM・なりすまし）

画像投稿の `user_id` とユーザー登録の `uid` をリクエストボディから採用していました。バリデーションは形式チェックのみで、トークンのUIDとの照合はありません。他人名義でのコンテンツ投稿や、被害者のメールアドレスの先取り登録（`email` が `@unique` のため本人の登録が恒久的にブロックされる）が可能でした。

型定義とバリデーションルールから該当フィールドを削除し、ボディ経由でIDを注入する経路自体を無くしています。

## その他の修正

- `getAuthenticatedUserid` の例外を `Error`（→500）から `AppError(..., 401)` に変更。メッセージも「画像削除するには〜」から汎用文言に修正
- `authMiddleware` がエラー時にレスポンス送信後 `next(error)` を呼んでおり `ERR_HTTP_HEADERS_SENT` が発生していた問題を修正
- 画像更新時の Storage 保存先を、ボディの `store_id` ではなく認可判定に使ったパスパラメータの `storeId` に統一
- Swagger に認証要件（`security`）と 401/403 レスポンスを追記

## レビュー指摘への対応

### ログへの認証情報流出を防止

`pino-http` はデフォルトのリクエストシリアライザでヘッダを丸ごと出力します。`LOG_LEVEL` の既定値は `warn`、pino-http のリクエストログは `info` レベルのため現状は出力されませんが、デバッグのために `LOG_LEVEL=info` にした瞬間に **Firebase IDトークンが平文でログに残ります**。`redact` で `authorization` / `cookie` をマスクしました。

### 入力検証の強化

`notEmpty()` は空白のみの文字列を通すため、店舗名を `"   "` にして保存できる状態でした。必須テキスト5項目を「型 → trim → 空判定 → 文字数」の順に統一しています。

`trim()` は値を文字列へ強制変換するサニタイザのため、`isString()` より前に置くと数値・オブジェクトが文字列化して型チェックをすり抜けます（`{}` が `【閉店】[object Object]` になる）。必ず型チェックの後に置いてください。

あわせて、検証ルールが存在しなかった任意項目4つ（`branch_name` / `topping_details` / `call_details` / `lot_detail`）にも型・文字数の検証を追加しました。既存クライアントを壊さないよう、未指定・`null`・空文字は従来どおり許容します。

### Firebase Storage と DB の整合性

`updateStoreImageService` が旧ファイルの削除を **DBコミット前** に実行していました。後続のDB更新が失敗するとレコードは旧URLを指したままファイルだけが失われ、画像が復旧不能になります。

「認可 → アップロード → DB更新 → 旧ファイル削除」の4段階に分離し、DB更新失敗時はアップロード済みファイルを削除する補償処理を追加しました。第3段階では `image_url` をトランザクション内で読み直し、並行更新があった場合に古いURLで上書きしないようにしています。

`deleteStoreImageService` は認可・関連削除・レコード削除を1トランザクションに統合し、Storage削除をコミット後に移動しました。`createImage` も同様にアップロードをトランザクション外へ出しています。

### 画像アップロードの入力検証

`image_base64` の型は `string | null` にもかかわらず non-null アサーション（`!`）で握りつぶしていたため、バリデーションを迂回すると TypeError となり500を返していました。引数を null 許容にして未設定チェックを追加し、アサーションを型安全に削除しています。

data URL を解析する正規表現は `image/svg+xml` や `text/html` も通すため、Content-Type がそのまま公開オブジェクトに設定されていました。拡張子の対応表をそのまま許可リストとして使う形に変更し、許可判定と拡張子判定が乖離しないようにしています。これに伴い、未知のMIMEタイプに既定値 `.jpg` を返していた `getFileExtensionFromMimeType` を削除しました。

## フロントエンド側で必要になる対応

1. `POST /stores`、`PUT /stores/:id`、`PATCH /stores/:id/close` に `Authorization: Bearer <IDトークン>` ヘッダを付与する
2. 画像の投稿・更新リクエストのボディから `user_id` を削除する（送信しても無視されます）
3. ユーザー登録リクエストのボディから `uid` を削除する（同上）
4. 他人のプロフィールを取得している画面があれば403になります
5. 店舗の必須テキスト項目に空白のみの値を送ると400になります。前後の空白は保存時に除去されます
6. `branch_name` は255文字、`topping_details` / `call_details` / `lot_detail` は1000文字を超えると400になります
7. 画像登録時の Base64 形式エラーのステータスが 500 から 400 に変わります

## 検証状況

DB（Docker / PostgreSQL 16）とアプリを実際に起動して検証しました。Firebase については、実IDトークンを発行せずに認可ロジックを検証するため `verifyIdToken` を、実バケットへ書き込まないため Storage を、それぞれスタブに差し替えています。ミドルウェア以降のコントローラ・サービスは本番と同一のコードが動作します。

いずれの項目も修正前のコミットを別ポートで並走させ、修正前後の差分として確認しました。

### 静的チェック

- `npx tsc --noEmit` — エラーなし
- `npx eslint src/` — エラーなし
- Swagger 仕様の生成 — 全書き込み系エンドポイントに認証要件が反映されていることを確認

### 認証の強制

トークン無し・不正トークンのいずれでも、`POST /stores`、`PUT /stores/:id`、`PATCH /stores/:id/close`、画像の POST/PUT/DELETE、`POST /users`、`GET /users/:uid` がすべて **401**。公開GET（`/stores`、`/stores/:id`、`/stores/:id/images`、`/toppings`）はすべて **200** で変化なし。

修正前は `POST /stores` が **400**（バリデーションエラー）を返しており、認証を素通りしてバリデーション層まで到達していたことが確認できました。

### 認可

| ケース | 結果 |
|---|---|
| 他人が画像を更新 / 削除 | 403 |
| 投稿者本人が画像を更新 | 200 |
| 管理者が他人の画像を更新 | 200 |
| 他人のユーザー情報を参照 | 403 |
| 本人が自分の情報を参照 | 200 |
| 管理者が他人の情報を参照 | 200 |

IDOR は修正前 **200 / 修正後 403**。修正前は DB の `menu_name` が実際に書き換わることも確認しました。

### `ERR_HTTP_HEADERS_SENT`

不正トークンで全エンドポイントを叩き、ログに `ERR_HTTP_HEADERS_SENT` と `UNHANDLED ERROR` が **0件**。

### ログのマスク

| ヘッダ | 修正前 | 修正後 |
|---|---|---|
| `authorization` | `Bearer eyJhbGciOiJSUzI1NiJ9.…`（平文） | `[Redacted]` |
| `cookie` | `session=…`（平文） | `[Redacted]` |
| その他のヘッダ | そのまま | そのまま |

### 入力検証

空白のみ（半角・全角）は全項目で拒否。前後の空白は除去して保存。型不一致は修正前は Prisma まで到達して **500** でしたが **400** になりました。文字数境界（255/256、1000/1001）も期待どおり。任意項目の未指定・`null`・空文字は従来どおり通過します。

### Storage と DB の整合性

Storage をスタブ化して操作の時系列を記録し、20項目を検証（**20パス / 0失敗**）。DB失敗は存在しないトッピングIDによるFK違反を注入して再現しました。

| 検証項目 | 修正前 | 修正後 |
|---|---|---|
| 認可失敗時にアップロードしない | OK | OK |
| DB失敗時に新ファイルを補償削除 | **失敗** | OK |
| DB失敗時に直前のファイルが残る（データ損失なし） | **失敗** | OK |
| 削除時に Storage のファイルも消える | **失敗** | OK |
| Storage削除時点でDB行が消えている（＝コミット後） | **失敗** | OK |

修正前の操作列は `save:NEW → makePublic:NEW → delete:OLD` で、DBがロールバックしても旧ファイルが復元されず、画像が永久に404になる状態を再現できました。

### MIMEタイプ

`text/html` / `image/svg+xml` は HTTP 経由では修正前から400で遮断されています（`imageValidation.ts` の許可リスト）。ただしサービスを直接呼ぶと修正前は `contentType="text/html"` かつ拡張子 `.jpg` で書き込まれていました。修正後はサービス層でも拒否されます。

### 未実施

実 Firebase Storage への書き込みを伴う経路は未実施です。検証はすべてスタブ化して行いました。

## 未対応

`GET /stores/:storeId/images` が Firebase UID を未認証で返す点は変更していません。本人確認の追加によりUIDから辿れる操作が無くなったため悪用経路は塞がっていますが、フロント側で「自分の投稿」判定に使っている可能性があり、削除するとUIが壊れるリスクがあるためです。使用していないことが確認できれば削除できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 店舗の作成・更新・閉店操作に認証を追加しました。
  - 画像の更新・削除を所有者または管理者に限定しました。
  - ユーザー情報の参照を本人または管理者に限定しました。
  - 店舗閉店時の入力検証を強化しました。

- **バグ修正**
  - 無効な認証トークンによる二重レスポンスを防止しました。
  - 認証エラー時に適切な401エラーを返すよう改善しました。

- **セキュリティ**
  - 認証情報がログに出力されないよう保護しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
