### PR TITLE
fix: バリデーションエラーレスポンスの重複解消と tsconfig の rootDir 明示

### DIFF
--- a/src/middlewares/validationMiddleware.ts
+++ b/src/middlewares/validationMiddleware.ts
@@ -16,11 +16,17 @@ export const handleValidationErrors = (req: Request, res: Response, next: NextFu
     const errors = validationResult(req)
     if (!errors.isEmpty()) {
         const logger = container.resolve<Logger>(pinoLogger)
+        // ログは原因調査のため全件残す（onlyFirstError を付けない）
         logger.error({ errors: errors.array(), path: req.originalUrl }, 'バリデーションエラーが発生しました。')
         res.status(400).json({
             success: false,
             error: 'バリデーションエラー発生：入力値に誤りがあります。',
-            details: errors.array()
+            // レスポンスはフィールドごとに先頭1件へ絞る。
+            // 必須テキスト項目は notEmpty → isString → trim → notEmpty の順で検証しており
+            // （検証順序の意図は validation.ts 冒頭コメントを参照）、bail() を挟んでいないため
+            // 1フィールドに同一メッセージが複数返る（例: "" に対し「必須です」が2件）。
+            // 合否は変わらず details の件数だけが減るため、既存クライアントへの影響はない。
+            details: errors.array({ onlyFirstError: true })
         })
         return
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "typeRoots": ["./node_modules/@types", "./src/types"],
     "types": ["node", "express"]


### PR DESCRIPTION
独立した2つの変更を含みます。コミットも分けています。

---

## 1. バリデーションエラーレスポンスの重複解消 (ccdad7a)

### 課題

express-validator は `bail()` が無いとチェーンの後続も実行するため、1フィールドに同一メッセージが複数返っていました。

| 送信値 | 変更前の `details` | 変更後 |
|---|---|---|
| `store_name: ""` | 2件（「必須です」×2） | **1件** |
| `store_name: null` | 3件（必須／文字列／必須） | **1件** |
| `store_name` キー省略 | 3件 | **1件** |

必須テキスト項目は `notEmpty → isString → trim → notEmpty` の順で検証しており（順序の意図は `validation.ts` 冒頭コメント参照）、trim 前後の `notEmpty()` が両方失敗するのが原因です。

### 対応

レスポンスのみ `errors.array({ onlyFirstError: true })` でフィールド先頭1件に絞りました。ログ側は原因調査に必要なため全件を維持しています。

### `.bail()` を採用しなかった理由

根本解決として各チェーンへの `.bail()` 挿入も検討し、実測で出力が完全一致することを確認しました（8パターンで差分0）。そのうえで以下の理由から本対応を選択しています。

- 約15チェーン30箇所の変更に対し、本対応は1行
- `.bail()` だとログ側の情報も落ちる（レスポンスとログを分離できない）
- 挿入漏れを検知するテストが現状存在しない

### 検証

- **合否(400/200)は不変** — 14パターン（`undefined` / `null` / `""` / `"   "` / 数値 / 真偽値 / `{}` / 配列 / 255文字 / 256文字 / 絵文字255 ほか）で差分 **0件**
- `details[].path` / `details[].value` も不変
- **複数フィールドが同時に不正な場合は全フィールド分を返す** — フォーム一括表示は維持
- 実サーバでの確認：必須4項目すべて `""` → 4件/4フィールド、全項目欠落 → 7件/7フィールド、正常系 → 201

---

## 2. tsconfig に rootDir を明示 (a2968ee)

TypeScript 6 から `outDir` 指定時に `rootDir` の明示が必須となり、新しい TypeScript を使う IDE で以下のエラーが出ていました。

```
The common source directory of 'tsconfig.json' is './src'.
The 'rootDir' setting must be explicitly set to this or another path
to adjust your output's file layout.
```

これまで推論されていた値と同じ `./src` を明示するだけの変更です。

**検証：** `dist` を削除して再ビルドし、js 35ファイルのパス構成が変更前と完全一致（`diff` 差分なし）。`npm start` が参照する `dist/app.js` の位置も不変。IDE 診断 0件。

---

## 影響範囲

- 既存クライアントへの破壊的変更なし（`details` は減る方向のみ）
- フロント側で重複除去を入れている場合、除去対象が0件になるだけで競合しません。**デプロイ順序の制約もありません**
- ビルド成果物に変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - バリデーションエラー発生時、エラーログには従来どおりすべてのエラーを記録しつつ、クライアントへの400レスポンスでは各フィールドの先頭エラーのみを返すようになりました。
  - これにより、レスポンス内容が簡潔になり、エラー内容を確認しやすくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->