### PR TITLE
fix: GET /stores/:id の500解消と CORS の許可オリジン制限

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,10 @@ FIREBASE_STORAGE_BUCKET="your-project-id.appspot.com"
 # Prisma
 PRISMA_TRANSACTION_MAX_WAIT="YOUR_MAX_WAIT_TIME"
 PRISMA_TRANSACTION_TIMEOUT="YOUR_TIMEOUT_TIME"
+
+# CORS
+# 許可するオリジンをカンマ区切りで指定します。
+# 本番環境（NODE_ENV=production）では必須です。未設定の場合、起動時にエラーで停止します。
+# 開発環境では未設定を許容し、その場合は全オリジンを許可します（起動時に警告ログを出力）。
+# 例: CORS_ALLOWED_ORIGINS=https://your-frontend.example.com,https://www.your-frontend.example.com
+CORS_ALLOWED_ORIGINS=

--- a/src/app.ts
+++ b/src/app.ts
@@ -76,9 +76,19 @@ app.use(helmet())
 /**
  * アプリケーション全体で使用するミドルウェアを定義
  * @property {Function} express.json() - JSONリクエストボディをパースするミドルウェア
- * @property {Function} cors() - CORSを有効にし、異なるオリジンからのリクエストを許可するミドルウェア
+ * @property {Function} cors() - CORSを有効にし、許可オリジンからのリクエストのみを受け付けるミドルウェア
+ *
+ * 許可オリジンは CORS_ALLOWED_ORIGINS（カンマ区切り）で指定する。
+ * 本番では未設定だと config 読み込み時点で起動に失敗する。
+ * 開発で未設定の場合のみ null となり、従来どおり全オリジンを許可する。
+ * 認証は Authorization ヘッダの Bearer トークン方式で Cookie を使わないため credentials は有効化しない。
  */
-app.use(cors())
+if (config.cors.allowedOrigins) {
+    app.use(cors({ origin: config.cors.allowedOrigins, credentials: false }))
+} else {
+    logger.warn('CORS_ALLOWED_ORIGINS が未設定のため、全オリジンからのリクエストを許可しています（開発環境のみ許容）')
+    app.use(cors())
+}
 app.use(express.json({ limit: '10mb' }))
 app.use(express.urlencoded({ extended: true, limit: '10mb' }))
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -90,7 +90,7 @@ app.use(express.urlencoded({ extended: true, limit: '10mb' }))
 app.use(router)
 
 // 404エラーハンドリング
-app.use((req, res, next) => {
+app.use((_req, _res, next) => {
   next(new AppError("Not Found", 404))
 })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -15,6 +15,28 @@ function getEnv(key: string): string {
 }
 
 /**
+ * カンマ区切りの許可オリジン文字列を配列へ変換する
+ * @param raw 環境変数の生値
+ * @param required 本番など、1件以上の指定を必須とするか
+ * @returns 許可オリジンの配列。未指定かつ required=false の場合は null（＝全許可）
+ */
+function parseOrigins(raw: string | undefined, required: boolean): string[] | null {
+    const origins = (raw ?? '')
+        .split(',')
+        .map(o => o.trim())
+        .filter(o => o.length > 0)
+
+    if (origins.length === 0) {
+        // getEnv は空文字なら throw するが、"," のみのような実質空の値はすり抜けるためここでも弾く
+        if (required) {
+            throw new AppError('CORS_ALLOWED_ORIGINS に有効なオリジンが1件も指定されていません', 500)
+        }
+        return null
+    }
+    return origins
+}
+
+/**
  * アプリケーション設定オブジェクト
  * アプリケーション全体で使用する設定値を集約
  */
@@ -40,6 +62,14 @@ const config = {
     // Google Maps APIキー
     google: {
         mapsApiKey: getEnv('GOOGLE_MAPS_API_KEY'),
+    },
+    // CORS設定
+    cors: {
+        // 本番では許可オリジンの明示を必須とする（未設定なら getEnv が起動時に throw）。
+        // 開発では未設定を許容し、その場合は null = 全オリジン許可（従来どおりの挙動）。
+        allowedOrigins: process.env.NODE_ENV === 'production'
+            ? parseOrigins(getEnv('CORS_ALLOWED_ORIGINS'), true)
+            : parseOrigins(process.env.CORS_ALLOWED_ORIGINS, false)
     },
     // Prisma
     prisma: {

--- a/src/middlewares/validation.ts
+++ b/src/middlewares/validation.ts
@@ -96,6 +96,18 @@ export const storeValidationRules = [
 ]
 
 /**
+ * 店舗ID（パスパラメータ）のバリデーションルール
+ * 検証が無いと Number('abc') → NaN のまま Prisma に渡り、
+ * 「ユーザーの入力ミス」が 500（予期せぬエラー）として返ってしまうため、
+ * ルート層で 400 に倒す
+ */
+export const storeIdParamValidationRules = [
+    param('id')
+        .notEmpty().withMessage('店舗IDは必須です')
+        .isInt().withMessage('店舗IDは整数で指定してください')
+]
+
+/**
  * 店舗閉店処理のバリデーションルール
  * store_nameはテンプレートリテラルで店舗名に直接埋め込まれるため、
  * 型・長さのチェックを必須とする

--- a/src/routes/store.routes.ts
+++ b/src/routes/store.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { StoreController } from "../controllers/storeController";
-import { storeCloseValidationRules, storeValidationRules } from "../middlewares/validation";
+import { storeCloseValidationRules, storeIdParamValidationRules, storeValidationRules } from "../middlewares/validation";
 import { createHandler } from "../utils/routeHandler";
 import { handleValidationErrors } from "../middlewares/validationMiddleware";
 import { authenticateUser } from "../middlewares/authMiddleware";
@@ -76,7 +76,7 @@ storeRouter.post('/', authenticateUser, storeValidationRules, handleValidationEr
  *       '404':
  *         $ref: '#/components/responses/StoreNotFound'
  */
-storeRouter.get('/:id', createHandler(StoreController, 'getStoreById'))
+storeRouter.get('/:id', storeIdParamValidationRules, handleValidationErrors, createHandler(StoreController, 'getStoreById'))
 
 /**
  * @swagger


### PR DESCRIPTION
PR #39 のレビュー時に挙がった別件2点の対応です。コミットは3つに分けています。

> ⚠️ **デプロイ前に対応が必要です**
> 本番環境に `CORS_ALLOWED_ORIGINS` を追加してください。未設定のまま `NODE_ENV=production` で起動すると**起動に失敗します**（意図的な fail-closed）。

---

## 1. `GET /stores/:id` が非数値IDで 500 を返す (7098a1e)

### 課題

`storeRouter.get('/:id')` にパラメータ検証が無く、`Number('abc')` → `NaN` がそのまま Prisma へ渡っていました。結果、**ユーザーの入力ミスが「サーバー内部で予期せぬエラー」(500) として返って**いました。

### 対応

`param('id')` の `notEmpty` / `isInt` を追加し、ルート層で 400 に倒します。メッセージは既存の `storeCloseValidationRules` の `param('id')` と揃えました。

### 検証（変更前 → 変更後）

| リクエスト | 変更前 | 変更後 |
|---|---|---|
| `GET /stores/abc` | **500** | **400**「店舗IDは整数で指定してください」 |
| `GET /stores/1.5` | **500** | **400**（小数も同時に解消） |
| `GET /stores/-1` | 404 | 404（正しい整数のため変化なし） |
| `GET /stores/999999` | 404 | 404（変化なし） |

`GET /stores/:id/toppingcalls` は `storeController.ts:120-123` に同等の検証が既にあり 400 を返していたため、今回は変更していません。**検証位置がルート層とコントローラ層で分かれている点は整理の余地があります**が、動作しているものに手を入れるとレスポンス形状（`details` の有無）が変わるため見送りました。

---

## 2. CORS が全オリジン許可 (6a8e77c)

### 課題

`app.use(cors())` がオプション未指定で、全オリジンからのリクエストを許可していました。認証は Authorization ヘッダの Bearer トークン方式なので Cookie 認証ほどの危険はありませんが、**認証不要エンドポイント（`GET /stores`、`GET /toppings` 等）は任意のサイトから叩ける状態**でした。

### 対応

`CORS_ALLOWED_ORIGINS`（カンマ区切り）で許可オリジンを指定する形にしました。

| 環境 | 未設定時の挙動 |
|---|---|
| 本番 (`NODE_ENV=production`) | **起動に失敗**（fail-closed） |
| 開発 | 従来どおり全オリジン許可。起動時に警告ログ |

本番を必須にしたのは、`config.ts` の既存の `getEnv()` が必須環境変数の未設定時に throw する流儀に合わせたためです。Cookie を使わないため `credentials` は有効化していません。

### 検証

| ケース | 結果 |
|---|---|
| 本番 + 未設定 / 空文字 | 🛑 起動失敗 |
| 本番 + `" , "`（実質空） | 🛑 起動失敗（`getEnv` をすり抜けるため別途弾く） |
| 本番 + 複数指定 | 空白を除去して配列化 |
| 開発 + 未設定 | `null`（全許可）＋警告ログ |
| 実サーバ・許可オリジン | `Access-Control-Allow-Origin` を返す |
| 実サーバ・未許可オリジン | ヘッダを返さない（ブラウザがブロック） |
| 実サーバ・`Origin` ヘッダ無し | 従来どおり通過（非ブラウザクライアントに影響なし） |

---

## 3. 404ハンドラの未使用引数 (55db1f1)

`next()` のみを使用し `req` / `res` を参照していないため、TS6133 が IDE に報告されていました。アンダースコア接頭辞を付けて解消しています。

---

## 確認事項

- `npx tsc --noEmit` / `npx eslint src/` ともにクリーン
- `.env.example` には雛形のみ追加。**本番の実URLは記載していません**ので、デプロイ環境側で設定してください
- ローカル `.env` は変更していません（開発は未設定でも従来どおり動作します）

🤖 Generated with [Claude Code](https://claude.com/claude-code)